### PR TITLE
Renamed disk file

### DIFF
--- a/Sources/tart/VMDirectory.swift
+++ b/Sources/tart/VMDirectory.swift
@@ -14,7 +14,7 @@ struct VMDirectory {
     baseURL.appendingPathComponent("config.json")
   }
   var diskURL: URL {
-    baseURL.appendingPathComponent("disk.bin")
+    baseURL.appendingPathComponent("disk.img")
   }
   var nvramURL: URL {
     baseURL.appendingPathComponent("nvram.bin")


### PR DESCRIPTION
.img is a standard extension for disk images on macOS. With this extension clicking on the file in finder it will be open in Dick Utilities for inspection.