### PR TITLE
Use GoReleaser for releases

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,6 @@
 task:
   name: Build
+  only_if: $CIRRUS_TAG == ''
   persistent_worker:
     labels:
       os: darwin
@@ -8,3 +9,15 @@ task:
   sign_script: codesign --sign - --entitlements Sources/tart/tart.entitlements --force .build/debug/tart
   binary_artifacts:
     path: .build/debug/tart
+
+task:
+  name: Release
+  only_if: $CIRRUS_TAG != ''
+  persistent_worker:
+    labels:
+      os: darwin
+      arch: arm64
+  env:
+    GITHUB_TOKEN: ENCRYPTED[!98ace8259c6024da912c14d5a3c5c6aac186890a8d4819fad78f3e0c41a4e0cd3a2537dd6e91493952fb056fa434be7c!]
+    GORELEASER_TOKEN: ENCRYPTED[!9b80b6ef684ceaf40edd4c7af93014ee156c8aba7e6e5795f41c482729887b5c31f36b651491d790f1f668670888d9fd!]
+  release_script: goreleaser

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ tart.xcodeproj/
 
 # Swift
 .build/
+
+# GoReleaser
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,40 @@
+project_name: tart
+
+builds:
+  - builder: prebuilt
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    prebuilt:
+      path: .build/{{ .Arch }}-apple-macosx/release/tart
+
+before:
+  hooks:
+    - swift build --product tart
+    
+after:
+  hooks:
+    - codesign --sign - --entitlements Sources/tart/tart.entitlements --force .build/arm64-apple-macosx/release/tart
+
+archives:
+  - id: binary
+    format: binary
+    name_template: "{{ .ProjectName }}"
+  - id: regular
+    name_template: "{{ .ProjectName }}"
+
+release:
+  prerelease: auto
+
+brews:
+  - name: tart
+    ids:
+      - regular
+    tap:
+      owner: cirruslabs
+      name: homebrew-cli
+    caveats: See the Github repository for more information
+    homepage: https://github.com/cirruslabs/tart
+    description: Run macOS VMs on Apple Silicon
+    skip_upload: auto


### PR DESCRIPTION
I just got a GoReleaser Pro to use the `prebuilt` feature. Seems like an overkill but we've been using GoReleaser for Cirrus CLI and will be great to give back some $$$. Plus we might use the Pro features for some other repos.