### PR TITLE
Renamed run command into start

### DIFF
--- a/.run/tart run.run.xml
+++ b/.run/tart run.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="tart run" type="SwiftPackageManagerRunConfiguration" factoryName="Swift Package Run" PROGRAM_PARAMS="run latest" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="tart" TARGET_NAME="tart" CONFIG_NAME="tart" RUN_TARGET_PROJECT_NAME="tart" RUN_TARGET_NAME="tart" WAS_MODIFIED="">
+  <configuration default="false" name="tart run" type="SwiftPackageManagerRunConfiguration" factoryName="Swift Package Run" PROGRAM_PARAMS="start latest" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="tart" TARGET_NAME="tart" CONFIG_NAME="tart" RUN_TARGET_PROJECT_NAME="tart" RUN_TARGET_NAME="tart" WAS_MODIFIED="">
     <method v="2">
       <option name="SPM.BUILD_TASK_PROVIDER" enabled="true" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="sign debug" run_configuration_type="ShConfigurationType" />

--- a/Sources/tart/Commands/Start.swift
+++ b/Sources/tart/Commands/Start.swift
@@ -5,8 +5,8 @@ import Virtualization
 
 var vm: VM?
 
-struct Run: AsyncParsableCommand {
-  static var configuration = CommandConfiguration(abstract: "Run a VM")
+struct Start: AsyncParsableCommand {
+  static var configuration = CommandConfiguration(abstract: "Start a VM")
 
   @Argument(help: "VM name")
   var name: String

--- a/Sources/tart/Root.swift
+++ b/Sources/tart/Root.swift
@@ -4,5 +4,5 @@ import ArgumentParser
 struct Root: AsyncParsableCommand {
   static var configuration = CommandConfiguration(
     commandName: "tart",
-    subcommands: [Create.self, Clone.self, Run.self, Set.self, List.self, IP.self, Delete.self])
+    subcommands: [Create.self, Clone.self, Start.self, Set.self, List.self, IP.self, Delete.self])
 }


### PR DESCRIPTION
It's more consistent with the way Parallels CLI works. Also initially run name was chosen to be similar to Docker but working with VMs is not like working with containers. `docker run` starts an ephemeral container where Tart actually runs a VM which is mutable.