### PR TITLE
Registry: suport pulling public images

### DIFF
--- a/Sources/tart/Credentials.swift
+++ b/Sources/tart/Credentials.swift
@@ -1,15 +1,7 @@
 import Foundation
 
 class Credentials {
-  static func retrieve(host: String) throws -> (String, String) {
-    do {
-      return try retrieveKeychain(host: host)
-    } catch RegistryError.AuthFailed {
-      return try retrieveStdin()
-    }
-  }
-
-  static func retrieveKeychain(host: String) throws -> (String, String) {
+  static func retrieveKeychain(host: String) throws -> (String, String)? {
     let query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
                                 kSecAttrProtocol as String: kSecAttrProtocolHTTPS,
                                 kSecAttrServer as String: host,
@@ -24,7 +16,7 @@ class Credentials {
 
     if status != errSecSuccess {
       if status == errSecItemNotFound {
-        throw RegistryError.AuthFailed(why: "Keychain item not found")
+        return nil
       }
 
       throw RegistryError.AuthFailed(why: "Keychain returned unsuccessful status \(status)")

--- a/Sources/tart/OCI/Registry.swift
+++ b/Sources/tart/OCI/Registry.swift
@@ -192,11 +192,12 @@ class Registry {
       }
     }
 
-    let (user, password) = try Credentials.retrieve(host: baseURL.host!)
-    let encodedCredentials = "\(user):\(password)".data(using: .utf8)?.base64EncodedString()
-    let headers = [
-      "Authorization": "Basic \(encodedCredentials!)"
-    ]
+    var headers: Dictionary<String, String> = Dictionary()
+
+    if let (user, password) = try Credentials.retrieveKeychain(host: baseURL.host!) {
+      let encodedCredentials = "\(user):\(password)".data(using: .utf8)?.base64EncodedString()
+      headers["Authorization"] = "Basic \(encodedCredentials!)"
+    }
 
     let (responseData, response) = try await rawRequest("GET", authenticateURL, headers: headers)
     if response.statusCode != 200 {


### PR DESCRIPTION
This makes Tart's pulling/pushing behavior more consistent to that of Docker.

You now have to first login to the registry to be able to do privileged things, yet you don't need to login if no authorization is required.