### PR TITLE
Print total size of compressed layers

### DIFF
--- a/Sources/tart/VMDirectory+OCI.swift
+++ b/Sources/tart/VMDirectory+OCI.swift
@@ -52,8 +52,10 @@ extension VMDirectory {
     }
 
     // Progress
-    defaultLogger.appendNewLine("pulling disk...")
-    let progress = Progress(totalUnitCount: Int64(diskLayers.map{ $0.size }.reduce(0) { $0 + $1 }))
+    let diskCompressedSize: Int64 = Int64(diskLayers.map {$0.size}.reduce(0) {$0 + $1})
+    let prettyDiskSize = String(format: "%.1f", Double(diskCompressedSize) / 1_000_000_000.0)
+    defaultLogger.appendNewLine("pulling disk (\(prettyDiskSize) GB compressed)...")
+    let progress = Progress(totalUnitCount: diskCompressedSize)
     ProgressObserver(progress).log(defaultLogger)
 
     for diskLayer in diskLayers {


### PR DESCRIPTION
Before pulling an image.

```console
tart pull ghcr.io/cirruslabs/macos-monterey-base:latest
pulling ghcr.io/cirruslabs/macos-monterey-base:latest...
pulling manifest...
pulling disk (18.1GB compressed)...
```