### PR TITLE
Registry: use issued_at field in the token response message

### DIFF
--- a/Sources/tart/OCI/Date+RFC3339.swift
+++ b/Sources/tart/OCI/Date+RFC3339.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+// RFC3339 date parser from DateFormatter documentation[1]
+//
+// [1]: https://developer.apple.com/documentation/foundation/dateformatter
+extension Date {
+  init?(fromRFC3339: String) {
+    let dateFormatter = DateFormatter()
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+    dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+    dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+
+    if let date = dateFormatter.date(from: fromRFC3339) {
+      self = date
+    } else {
+      return nil
+    }
+  }
+}

--- a/Tests/TartTests/TokenResponseTests.swift
+++ b/Tests/TartTests/TokenResponseTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import tart
+
+final class TokenResponseTests: XCTestCase {
+  func testBasic() throws {
+    let tokenResponseRaw = Data("{\"token\":\"some token\"}".utf8)
+    let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: tokenResponseRaw)
+
+    XCTAssertEqual(tokenResponse.token, "some token")
+  }
+
+  func testExpirationBasic() throws {
+    let tokenResponseRaw = Data("{\"token\":\"some token\",\"expires_in\":2}".utf8)
+    let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: tokenResponseRaw)
+
+    XCTAssertEqual(tokenResponse.expiresIn, 2)
+
+    let expectedTokenExpiresAtRange = Date()...Date().addingTimeInterval(2)
+    XCTAssertTrue(expectedTokenExpiresAtRange.contains(tokenResponse.tokenExpiresAt))
+
+    XCTAssertTrue(tokenResponse.isValid)
+    _ = XCTWaiter.wait(for: [expectation(description: "Wait 3 seconds for the token to become invalid")], timeout: 2)
+    XCTAssertFalse(tokenResponse.isValid)
+  }
+
+  func testExpirationWithIssuedAt() throws {
+    let tokenResponseRaw = Data("{\"token\":\"some token\",\"expires_in\":3600,\"issued_at\":\"1970-01-01T00:00:00Z\"}".utf8)
+    let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: tokenResponseRaw)
+
+    XCTAssertEqual(Date(timeIntervalSince1970: 3600), tokenResponse.tokenExpiresAt)
+  }
+}


### PR DESCRIPTION
A follow-up to https://github.com/cirruslabs/tart/pull/55.