### PR TITLE
Change default disk size upon creation

### DIFF
--- a/Sources/tart/Commands/Create.swift
+++ b/Sources/tart/Commands/Create.swift
@@ -13,7 +13,7 @@ struct Create: AsyncParsableCommand {
   var fromIPSW: String?
 
   @Option(help: ArgumentHelp("Disk size in Gb")) 
-  var diskSize: UInt8 = 32
+  var diskSize: UInt8 = 50
 
   func validate() throws {
     if fromIPSW == nil {


### PR DESCRIPTION
To help with frustrations like https://github.com/cirruslabs/tart/issues/44#issuecomment-1126831261

Experts will still use `--disk-size` flag to tailor disk size for their needs.