### PR TITLE
tart list: filter out uninitialized VM directories

### DIFF
--- a/Sources/tart/VMStorageLocal.swift
+++ b/Sources/tart/VMStorageLocal.swift
@@ -36,8 +36,12 @@ class VMStorageLocal {
       return try FileManager.default.contentsOfDirectory(
         at: baseURL,
         includingPropertiesForKeys: [.isDirectoryKey],
-        options: .skipsSubdirectoryDescendants).map { url in
+        options: .skipsSubdirectoryDescendants).compactMap { url in
         let vmDir = VMDirectory(baseURL: url)
+
+        if !vmDir.initialized {
+          return nil
+        }
 
         return (vmDir.name, vmDir)
       }


### PR DESCRIPTION
Similarly to what's done in `VMStorageOCI`: https://github.com/cirruslabs/tart/blob/efc9c74b6c557862fad8f5d1316976d3f772eb33/Sources/tart/VMStorageOCI.swift#L45-L47

Resolves https://github.com/cirruslabs/tart/issues/75.