### PR TITLE
Support "tart --version"

### DIFF
--- a/.ci/set-version.sh
+++ b/.ci/set-version.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cat Sources/tart/CI/CI.swift | envsubst | tee Sources/tart/CI/CI.swift

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
 
 before:
   hooks:
+    - cat Sources/tart/CI/CI.swift | envsubst | tee Sources/tart/CI/CI.swift
     - swift build -c release --product tart
     - codesign --sign - --entitlements Resources/tart.entitlements --force .build/arm64-apple-macosx/release/tart
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
 
 before:
   hooks:
-    - cat Sources/tart/CI/CI.swift | envsubst | tee Sources/tart/CI/CI.swift
+    - .ci/set-version.sh
     - swift build -c release --product tart
     - codesign --sign - --entitlements Resources/tart.entitlements --force .build/arm64-apple-macosx/release/tart
 

--- a/Sources/tart/CI/CI.swift
+++ b/Sources/tart/CI/CI.swift
@@ -1,0 +1,13 @@
+struct CI {
+  private static let rawVersion = "${CIRRUS_TAG}"
+
+  static var version: String {
+    rawVersion.expanded() ? rawVersion : "SNAPSHOT"
+  }
+}
+
+private extension String {
+  func expanded() -> Bool {
+    !isEmpty && !starts(with: "$")
+  }
+}

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -62,11 +62,26 @@ struct Run: AsyncParsableCommand {
                   CommandGroup(replacing: .textEditing, addition: {})
                   CommandGroup(replacing: .undoRedo, addition: {})
                   CommandGroup(replacing: .windowSize, addition: {})
+                  // Replace some standard menu options
+                  CommandGroup(replacing: .appInfo) { AboutTart() }
                 }
       }
     }
 
     MainApp.main()
+  }
+}
+
+struct AboutTart: View {
+  var body: some View {
+    Button("About Tart") {
+      NSApplication.shared.orderFrontStandardAboutPanel(options: [
+        NSApplication.AboutPanelOptionKey.applicationIcon: NSApplication.shared.applicationIconImage as Any,
+        NSApplication.AboutPanelOptionKey.applicationName: "Tart",
+        NSApplication.AboutPanelOptionKey.applicationVersion: CI.version,
+        NSApplication.AboutPanelOptionKey.credits: try! NSAttributedString(markdown: "https://github.com/cirruslabs/tart"),
+      ])
+    }
   }
 }
 

--- a/Sources/tart/Root.swift
+++ b/Sources/tart/Root.swift
@@ -5,6 +5,7 @@ import Foundation
 struct Root: AsyncParsableCommand {
   static var configuration = CommandConfiguration(
     commandName: "tart",
+    version: CI.version,
     subcommands: [
       Create.self,
       Clone.self,


### PR DESCRIPTION
Some explainer on why we need to use things like `envsubst`:

* https://stackoverflow.com/questions/27804227/using-compiler-variables-in-swift
* https://medium.com/@lucianoalmeida1/continuous-integration-environment-variables-in-ios-projects-using-swift-f72e50176a91

Resolves https://github.com/cirruslabs/tart/issues/42.