### PR TITLE
Fixed build warnings

### DIFF
--- a/Sources/tart/OCI/Registry.swift
+++ b/Sources/tart/OCI/Registry.swift
@@ -26,8 +26,8 @@ extension HTTPClientResponse.Body {
 }
 
 struct TokenResponse: Decodable {
-  static let defaultIssuedAt = Date()
-  static let defaultExpiresIn = 60
+  private static let defaultIssuedAt = Date()
+  private static let defaultExpiresIn = 60
 
   var token: String
   var expiresIn: Int?

--- a/Sources/tart/OCI/Registry.swift
+++ b/Sources/tart/OCI/Registry.swift
@@ -26,8 +26,8 @@ extension HTTPClientResponse.Body {
 }
 
 struct TokenResponse: Decodable {
-  let defaultIssuedAt = Date()
-  let defaultExpiresIn = 60
+  static let defaultIssuedAt = Date()
+  static let defaultExpiresIn = 60
 
   var token: String
   var expiresIn: Int?
@@ -61,7 +61,7 @@ struct TokenResponse: Decodable {
       //
       // [1]: https://docs.docker.com/registry/spec/auth/token/#requesting-a-token
 
-      (issuedAt ?? defaultIssuedAt) + TimeInterval(expiresIn ?? defaultExpiresIn)
+      (issuedAt ?? TokenResponse.defaultIssuedAt) + TimeInterval(expiresIn ?? TokenResponse.defaultExpiresIn)
     }
   }
 


### PR DESCRIPTION
`swift build` is not printing any warnings now