### PR TITLE
Auto-detect screen DPI 

### DIFF
--- a/Sources/tart/Commands/Set.swift
+++ b/Sources/tart/Commands/Set.swift
@@ -13,7 +13,7 @@ struct Set: AsyncParsableCommand {
   @Option(help: "VM memory size in megabytes")
   var memory: UInt16?
 
-  @Option(help: "VM display settings in a format of <width>x<height>(x<dpi>)?. For example, 1200x800 or 1200x800x72")
+  @Option(help: "VM display resolution in a format of <width>x<height>. For example, 1200x800")
   var display: VMDisplayConfig?
 
   @Option(help: .hidden)
@@ -39,9 +39,6 @@ struct Set: AsyncParsableCommand {
         if (display.height > 0) {
           vmConfig.display.height = display.height
         }
-        if (display.dpi > 0) {
-          vmConfig.display.dpi = display.dpi
-        }
       }
 
       try vmConfig.save(toURL: vmDir.configURL)
@@ -66,8 +63,7 @@ extension VMDisplayConfig: ExpressibleByArgument {
     }
     self = VMDisplayConfig(
       width: parts[safe: 0] ?? 0,
-      height: parts[safe: 1] ?? 0,
-      dpi: parts[safe: 2] ?? 0
+      height: parts[safe: 1] ?? 0
     )
   }
 }

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -172,13 +172,23 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
 
     // Display
     let graphicsDeviceConfiguration = VZMacGraphicsDeviceConfiguration()
-    graphicsDeviceConfiguration.displays = [
-      VZMacGraphicsDisplayConfiguration(
-        widthInPixels: vmConfig.display.width,
-        heightInPixels: vmConfig.display.height,
-        pixelsPerInch: vmConfig.display.dpi
+    if let hostMainScreen = NSScreen.main {
+      let vmScreenSize = NSSize(
+        width: vmConfig.display.width,
+        height: vmConfig.display.height
       )
-    ]
+      graphicsDeviceConfiguration.displays = [
+        VZMacGraphicsDisplayConfiguration(for: hostMainScreen, sizeInPoints: vmScreenSize)
+      ]
+    } else {
+      graphicsDeviceConfiguration.displays = [
+        VZMacGraphicsDisplayConfiguration(
+          widthInPixels: vmConfig.display.width,
+          heightInPixels: vmConfig.display.height,
+          pixelsPerInch: 72
+        )
+      ]
+    }
     configuration.graphicsDevices = [graphicsDeviceConfiguration]
 
     // Audio

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -185,6 +185,7 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
         VZMacGraphicsDisplayConfiguration(
           widthInPixels: vmConfig.display.width,
           heightInPixels: vmConfig.display.height,
+          // Reasonable guess like https://developer.apple.com/documentation/coregraphics/1456599-cgdisplayscreensize    
           pixelsPerInch: 72
         )
       ]

--- a/Sources/tart/VMConfig.swift
+++ b/Sources/tart/VMConfig.swift
@@ -29,7 +29,6 @@ enum CodingKeys: String, CodingKey {
 struct VMDisplayConfig: Codable {
   var width: Int = 1024
   var height: Int = 768
-  var dpi: Int = 72
 }
 
 struct VMConfig: Codable {


### PR DESCRIPTION
It appeared there is a hand `(for screen: NSScreen, sizeInPoints: NSSize)` constructor of `VZMacGraphicsDisplayConfiguration` which does the configuration for us. So since a new windows always opens on the main screen, let's use this constructor in case there is a main screen. Otherwise we'll do a reasonable guess of the DPI.

Fixes #104 