### PR TITLE
Make sure VM directory exists before moving

### DIFF
--- a/Sources/tart/VMStorageLocal.swift
+++ b/Sources/tart/VMStorageLocal.swift
@@ -28,9 +28,8 @@ class VMStorageLocal {
   }
 
   func move(_ name: String, from: VMDirectory) throws {
-    let newVmURL = vmURL(name)
-    _ = try FileManager.default.createDirectory(at: newVmURL, withIntermediateDirectories: true)
-    _ = try FileManager.default.replaceItemAt(newVmURL, withItemAt: from.baseURL)
+    _ = try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+    _ = try FileManager.default.replaceItemAt(vmURL(name), withItemAt: from.baseURL)
   }
 
   func delete(_ name: String) throws {

--- a/Sources/tart/VMStorageLocal.swift
+++ b/Sources/tart/VMStorageLocal.swift
@@ -28,7 +28,9 @@ class VMStorageLocal {
   }
 
   func move(_ name: String, from: VMDirectory) throws {
-    _ = try FileManager.default.replaceItemAt(vmURL(name), withItemAt: from.baseURL)
+    let newVmURL = vmURL(name)
+    _ = try FileManager.default.createDirectory(at: newVmURL, withIntermediateDirectories: true)
+    _ = try FileManager.default.replaceItemAt(newVmURL, withItemAt: from.baseURL)
   }
 
   func delete(_ name: String) throws {


### PR DESCRIPTION
Otherwise there might an error like this during the very first clone:

```console
$: tart clone ghcr.io/cirruslabs/macos-monterey-vanilla:12.3.1 test-old
Error Domain=NSCocoaErrorDomain Code=4 "The file “test-old” doesn’t exist." UserInfo={NSFileOriginalItemLocationKey=file:///Users/fedor/.tart/vms/test-old/, NSURL=file:///Users/fedor/.tart/vms/test-old/, NSFileNewItemLocationKey=file:///var/folders/tq/8ph0hm796qg72yrfqx55685w0000gn/T/08537077-A16F-4F2F-9716-8DD26249D494, NSUnderlyingError=0x600003644870 {Error Domain=NSCocoaErrorDomain Code=4 "The file “08537077-A16F-4F2F-9716-8DD26249D494” doesn’t exist." UserInfo={NSURL=file:///var/folders/tq/8ph0hm796qg72yrfqx55685w0000gn/T/08537077-A16F-4F2F-9716-8DD26249D494, NSFilePath=/var/folders/tq/8ph0hm796qg72yrfqx55685w0000gn/T/08537077-A16F-4F2F-9716-8DD26249D494, NSUnderlyingError=0x600003644930 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}}}
```