### PR TITLE
Registry: log upload location when encountering blob pushing error

### DIFF
--- a/Sources/tart/OCI/Registry.swift
+++ b/Sources/tart/OCI/Registry.swift
@@ -184,8 +184,8 @@ class Registry {
       body: fromData)
     if putResponse.status != .created {
       let body = try await postResponse.body.readTextResponse()
-      throw RegistryError.UnexpectedHTTPStatusCode(when: "pushing blob (PUT)", code: putResponse.status.code,
-        details: body ?? "")
+      throw RegistryError.UnexpectedHTTPStatusCode(when: "pushing blob (PUT) to \(uploadLocation)",
+              code: putResponse.status.code, details: body ?? "")
     }
 
     return digest


### PR DESCRIPTION
To help with the debugging of https://github.com/cirruslabs/tart/issues/120.