### PR TITLE
Fixes for Ventura

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -65,7 +65,9 @@ struct Run: AsyncParsableCommand {
       } catch {
         print("Failed to get an IP for screen sharing: \(error)")
       }
-      vm?.wait()
+      while !(vm?.inFinalState ?? false) {
+        try await Task.sleep(nanoseconds: 1_000_000)
+      }
     } else if !noGraphics {
       runUI()
     }

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -78,6 +78,10 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     return expectedIPSWLocation
   }
 
+  func wait() {
+    sema.wait()
+  }
+
   init(vmDir: VMDirectory, ipswURL: URL?, diskSizeGB: UInt16) async throws {
     let ipswURL = ipswURL != nil ? ipswURL! : try await VM.retrieveLatestIPSW();
 

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -77,9 +77,14 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     try data.write(to: expectedIPSWLocation, options: [.atomic])
     return expectedIPSWLocation
   }
-
-  func wait() {
-    sema.wait()
+  
+  var inFinalState: Bool {
+    get {
+      virtualMachine.state == VZVirtualMachine.State.stopped ||
+        virtualMachine.state == VZVirtualMachine.State.paused ||
+        virtualMachine.state == VZVirtualMachine.State.error
+      
+    }
   }
 
   init(vmDir: VMDirectory, ipswURL: URL?, diskSizeGB: UInt16) async throws {


### PR DESCRIPTION
Still a noob in SwiftUI and Swift concurrency, but it seems on Ventura a task group is not actually running on main or something. Either way I think this change simplifies things but launching a VM in a task and then just continuing with either VNC or built-in graphics.