### PR TITLE
Homebrew: depend on Softnet package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,5 +36,7 @@ brews:
     homepage: https://github.com/cirruslabs/tart
     description: Run macOS VMs on Apple Silicon
     skip_upload: auto
+    dependencies:
+      - "cirruslabs/cli/softnet"
     custom_block: |
       depends_on :macos => :monterey


### PR DESCRIPTION
So that `tart run --with-softnet` works out of the box.

See https://github.com/cirruslabs/tart/pull/48#issuecomment-1161972483.