### PR TITLE
tart run: return exit status 2 when VM is already running

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -81,10 +81,10 @@ struct Run: AsyncParsableCommand {
       } catch {
         if error.localizedDescription.contains("Failed to lock auxiliary storage.") {
           print("Virtual machine \"\(name)\" is already running!")
-        } else {
-          print(error)
+          Foundation.exit(2)
         }
 
+        print(error)
         Foundation.exit(1)
       }
     }


### PR DESCRIPTION
Resolves https://github.com/cirruslabs/tart/issues/151.