### PR TITLE
OCI's HTTP client: prevent the usage of NIO Transport Services

### DIFF
--- a/Sources/tart/OCI/Registry.swift
+++ b/Sources/tart/OCI/Registry.swift
@@ -2,6 +2,7 @@ import Foundation
 import NIOCore
 import NIOHTTP1
 import AsyncHTTPClient
+import NIOPosix
 
 enum RegistryError: Error {
   case UnexpectedHTTPStatusCode(when: String, code: UInt, details: String = "")
@@ -75,8 +76,10 @@ struct TokenResponse: Decodable, Authentication {
 }
 
 class Registry {
-  private let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
-  
+  private let httpClient = HTTPClient(
+    eventLoopGroupProvider: .shared(MultiThreadedEventLoopGroup(numberOfThreads: 1))
+  )
+
   deinit {
     try! httpClient.syncShutdown()
   }


### PR DESCRIPTION
It turns out that:

* the [AsyncHTTPClient](https://github.com/swift-server/async-http-client) package uses [`NIOTSEventLoopGroup()`](https://github.com/swift-server/async-http-client/blob/14fa6d944d88e5702ba630f8a8843966331fd944/Sources/AsyncHTTPClient/HTTPClient.swift#L103) as event loop group
* ...which uses [NIO Transport Services](https://github.com/apple/swift-nio-transport-services)
* ...which in turn uses [`Network.Framework`](https://developer.apple.com/documentation/network)

...which behaves wildly inefficient for reasons that can't be diagnosed easily without getting source code access:

<img width="1624" alt="Screenshot 2022-08-02 at 02 08 00" src="https://user-images.githubusercontent.com/85709/182248850-d21c9527-7251-4795-8f6b-341d856c198a.png">

However, we can force the AsyncHTTPClient to take a different path by manually specifying the event loop group provider.

This seems to be a simpler and faster alternative than https://github.com/cirruslabs/tart/pull/159: I'm getting 10x the speed of `main` branch and that of the chunked variant with way less CPU usage.

Resolves https://github.com/cirruslabs/tart/issues/158, https://github.com/cirruslabs/tart/issues/165.