### PR TITLE
tart login: read whole stdin contents instead of just a line

### DIFF
--- a/Sources/tart/Commands/Login.swift
+++ b/Sources/tart/Commands/Login.swift
@@ -30,7 +30,9 @@ struct Login: AsyncParsableCommand {
 
       if let username = username {
         user = username
-        password = readLine()!
+
+        let passwordData = FileHandle.standardInput.readDataToEndOfFile()
+        password = String(decoding: passwordData, as: UTF8.self)
       } else {
         (user, password) = try StdinCredentials.retrieve()
       }


### PR DESCRIPTION
Resolves https://github.com/cirruslabs/tart/issues/166.