### PR TITLE
OCI: support insecure registries and custom ports

### DIFF
--- a/Sources/tart/Commands/Login.swift
+++ b/Sources/tart/Commands/Login.swift
@@ -14,6 +14,9 @@ struct Login: AsyncParsableCommand {
   @Flag(help: "password-stdin")
   var passwordStdin: Bool = false
 
+  @Flag(help: "connect to the OCI registry via insecure HTTP protocol")
+  var insecure: Bool = false
+
   func validate() throws {
     let usernameProvided = username != nil
     let passwordProvided = passwordStdin
@@ -41,7 +44,8 @@ struct Login: AsyncParsableCommand {
       ])
 
       do {
-        let registry = try Registry(host: host, namespace: "", credentialsProvider: credentialsProvider)
+        let registry = try Registry(host: host, namespace: "", insecure: insecure,
+          credentialsProvider: credentialsProvider)
         try await registry.ping()
       } catch {
         print("invalid credentials: \(error)")

--- a/Sources/tart/Commands/Push.swift
+++ b/Sources/tart/Commands/Push.swift
@@ -12,6 +12,9 @@ struct Push: AsyncParsableCommand {
   @Argument(help: "remote VM name(s)")
   var remoteNames: [String]
 
+  @Flag(help: "connect to the OCI registry via insecure HTTP protocol")
+  var insecure: Bool = false
+
   @Option(help: ArgumentHelp("chunk size in MB if registry supports chunked uploads",
     discussion: """
                 By default monolithic method is used for uploading blobs to the registry but some registries support a more efficient chunked method.
@@ -45,7 +48,8 @@ struct Push: AsyncParsableCommand {
 
       // Push VM
       for (registryIdentifier, remoteNamesForRegistry) in registryGroups {
-        let registry = try Registry(host: registryIdentifier.host, namespace: registryIdentifier.namespace)
+        let registry = try Registry(host: registryIdentifier.host, namespace: registryIdentifier.namespace,
+          insecure: insecure)
 
         defaultLogger.appendNewLine("pushing \(localName) to "
           + "\(registryIdentifier.host)/\(registryIdentifier.namespace)\(remoteNamesForRegistry.referenceNames())...")

--- a/Sources/tart/OCI/Registry.swift
+++ b/Sources/tart/OCI/Registry.swift
@@ -104,13 +104,11 @@ class Registry {
   convenience init(
     host: String,
     namespace: String,
+    insecure: Bool = false,
     credentialsProvider: CredentialsProvider = KeychainCredentialsProvider()
   ) throws {
-    var baseURLComponents = URLComponents()
-
-    baseURLComponents.scheme = "https"
-    baseURLComponents.host = host
-    baseURLComponents.path = "/v2/"
+    let proto = insecure ? "http" : "https"
+    let baseURLComponents = URLComponents(string: proto + "://" + host + "/v2/")!
 
     try self.init(urlComponents: baseURLComponents, namespace: namespace, credentialsProvider: credentialsProvider)
   }


### PR DESCRIPTION
Might be helpful for debugging against a local Docker Registry and also for #131.