### PR TITLE
Do not include Content-Range for monolithic uploads

### DIFF
--- a/Sources/tart/OCI/Registry.swift
+++ b/Sources/tart/OCI/Registry.swift
@@ -191,7 +191,7 @@ class Registry {
       )
       if response.status != .created {
         let body = try await response.body.readTextResponse()
-        throw RegistryError.UnexpectedHTTPStatusCode(when: "streaming blob to \(uploadLocation)",
+        throw RegistryError.UnexpectedHTTPStatusCode(when: "pushing blob (PUT) to \(uploadLocation)",
           code: response.status.code, details: body ?? "")
       }
       return digest

--- a/Sources/tart/OCI/Registry.swift
+++ b/Sources/tart/OCI/Registry.swift
@@ -177,7 +177,27 @@ class Registry {
     var uploadLocation = try uploadLocationFromResponse(postResponse)
 
     let digest = Digest.hash(fromData)
+    
+    if chunkSizeMb == 0 {
+      // monolithic upload
+      let response = try await rawRequest(
+        .PUT,
+        uploadLocation,
+        headers: [
+          "Content-Type": "application/octet-stream",
+        ],
+        parameters: ["digest": digest],
+        body: fromData
+      )
+      if response.status != .created {
+        let body = try await response.body.readTextResponse()
+        throw RegistryError.UnexpectedHTTPStatusCode(when: "streaming blob to \(uploadLocation)",
+          code: response.status.code, details: body ?? "")
+      }
+      return digest
+    }
 
+    // chunked upload
     var uploadedBytes = 0
     let chunks = fromData.chunks(ofCount: chunkSizeMb == 0 ? fromData.count : chunkSizeMb * 1_000_000)
     for (index, chunk) in chunks.enumerated() {


### PR DESCRIPTION
Some registries still assumes it's a chunked upload and verifies the "chunk" size which is too big.