### PR TITLE
OCI blob compression: fix Data memory leak when using InputFilter

### DIFF
--- a/Sources/tart/VMDirectory+OCI.swift
+++ b/Sources/tart/VMDirectory+OCI.swift
@@ -125,7 +125,7 @@ extension VMDirectory {
       let data = mappedDisk.subdata(in: mappedDiskReadOffset ..< mappedDiskReadOffset + bytesRead)
       mappedDiskReadOffset += bytesRead
 
-      progress.completedUnitCount += Int64(bytesRead)
+      progress.completedUnitCount = Int64(mappedDiskReadOffset)
 
       return data
     }

--- a/Sources/tart/VMDirectory+OCI.swift
+++ b/Sources/tart/VMDirectory+OCI.swift
@@ -119,11 +119,11 @@ extension VMDirectory {
     // and sequentially upload them as blobs
     let mappedDisk = try Data(contentsOf: diskURL, options: [.alwaysMapped])
     let mappedDiskSize = mappedDisk.count
-    var mappedDiskOffset = 0
+    var mappedDiskReadOffset = 0
     let compressingFilter = try InputFilter(.compress, using: .lz4, bufferCapacity: Self.bufferSizeBytes) { (length: Int) -> Data? in
-      let bytesRead = min(length, mappedDiskSize - mappedDiskOffset)
-      let data = mappedDisk.subdata(in: mappedDiskOffset ..< mappedDiskOffset + bytesRead)
-      mappedDiskOffset += bytesRead
+      let bytesRead = min(length, mappedDiskSize - mappedDiskReadOffset)
+      let data = mappedDisk.subdata(in: mappedDiskReadOffset ..< mappedDiskReadOffset + bytesRead)
+      mappedDiskReadOffset += bytesRead
 
       progress.completedUnitCount += Int64(bytesRead)
 
@@ -147,7 +147,7 @@ extension VMDirectory {
     let manifest = OCIManifest(
             config: OCIManifestConfig(size: ociConfigJSON.count, digest: ociConfigDigest),
             layers: layers,
-            uncompressedDiskSize: UInt64(mappedDiskOffset)
+            uncompressedDiskSize: UInt64(mappedDiskReadOffset)
     )
 
     // Manifest

--- a/Sources/tart/VMDirectory+OCI.swift
+++ b/Sources/tart/VMDirectory+OCI.swift
@@ -117,13 +117,15 @@ extension VMDirectory {
 
     // Read VM's compressed disk as chunks
     // and sequentially upload them as blobs
-    let disk = try FileHandle(forReadingFrom: diskURL)
-    var diskReadBytes: UInt64 = 0
-    let compressingFilter = try InputFilter<Data>(.compress, using: .lz4, bufferCapacity: Self.bufferSizeBytes) { _ in
-      let data = try disk.read(upToCount: Self.bufferSizeBytes)
-      diskReadBytes += UInt64(data?.count ?? 0)
+    let mappedDisk = try Data(contentsOf: diskURL, options: [.alwaysMapped])
+    let mappedDiskSize = mappedDisk.count
+    var mappedDiskOffset = 0
+    let compressingFilter = try InputFilter(.compress, using: .lz4, bufferCapacity: Self.bufferSizeBytes) { (length: Int) -> Data? in
+      let bytesRead = min(length, mappedDiskSize - mappedDiskOffset)
+      let data = mappedDisk.subdata(in: mappedDiskOffset ..< mappedDiskOffset + bytesRead)
+      mappedDiskOffset += bytesRead
 
-      progress.completedUnitCount += Int64(data?.count ?? 0)
+      progress.completedUnitCount += Int64(bytesRead)
 
       return data
     }
@@ -145,7 +147,7 @@ extension VMDirectory {
     let manifest = OCIManifest(
             config: OCIManifestConfig(size: ociConfigJSON.count, digest: ociConfigDigest),
             layers: layers,
-            uncompressedDiskSize: diskReadBytes
+            uncompressedDiskSize: UInt64(mappedDiskOffset)
     )
 
     // Manifest


### PR DESCRIPTION
This makes Tart use `mmap(2)`-backed `Data` and `InputFilter(.compress, ...)` logic from [Apple's documentation](https://developer.apple.com/documentation/accelerate/compressing_and_decompressing_data_with_input_and_output_filters#3328720), which fixes the memory leak and results in smooth memory usage overall:

![](https://user-images.githubusercontent.com/85709/185188778-b9009db5-3a77-4763-8f5a-36b90c54b693.png)

(this shows a lifetime of a Tart instance that pushed a 120 GB disk to the registry)

Resolves https://github.com/cirruslabs/tart/issues/165.