### PR TITLE
Implement garbage collection when deleting cached OCI VMs

### DIFF
--- a/Sources/tart/VMDirectory.swift
+++ b/Sources/tart/VMDirectory.swift
@@ -20,6 +20,10 @@ struct VMDirectory: Prunable {
     baseURL.appendingPathComponent("nvram.bin")
   }
 
+  var explicitlyPulledMark: URL {
+    baseURL.appendingPathComponent(".explicitly-pulled")
+  }
+
   var name: String {
     baseURL.lastPathComponent
   }
@@ -88,5 +92,13 @@ struct VMDirectory: Prunable {
 
   func sizeBytes() throws -> Int {
     try configURL.sizeBytes() + diskURL.sizeBytes() + nvramURL.sizeBytes()
+  }
+
+  func markExplicitlyPulled() {
+    FileManager.default.createFile(atPath: explicitlyPulledMark.path, contents: nil)
+  }
+
+  func isExplicitlyPulled() -> Bool {
+    FileManager.default.fileExists(atPath: explicitlyPulledMark.path)
   }
 }

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -82,10 +82,10 @@ class VMStorageOCI: PrunableStorage {
   func pull(_ name: RemoteName, registry: Registry) async throws {
     defaultLogger.appendNewLine("pulling manifest...")
 
-    let (manifest, _) = try await registry.pullManifest(reference: name.reference.value)
+    let (manifest, manifestData) = try await registry.pullManifest(reference: name.reference.value)
 
-    var digestName = RemoteName(host: name.host, namespace: name.namespace,
-            reference: Reference(digest: try manifest.digest()))
+    let digestName = RemoteName(host: name.host, namespace: name.namespace,
+            reference: Reference(digest: Digest.hash(manifestData)))
 
     if !exists(digestName) {
       let tmpVMDir = try VMDirectory.temporary()


### PR DESCRIPTION
Also contains a fix for digest calculation for remotely-retrieved manifests in f734f0b5d0ef6bf17922c5b568b5f27c00ecc5d0.

Resolves https://github.com/cirruslabs/tart/issues/37.