### PR TITLE
testGetAndSetAccessTime: fix flakiness

### DIFF
--- a/Sources/tart/URL+AccessDate.swift
+++ b/Sources/tart/URL+AccessDate.swift
@@ -20,6 +20,6 @@ extension URL {
 
 extension Date {
   func asTimeval() -> timeval {
-    timeval(tv_sec: timeIntervalSince1970.toUnit(.second)!, tv_usec: 0)
+    timeval(tv_sec: Int(timeIntervalSince1970), tv_usec: 0)
   }
 }


### PR DESCRIPTION
Seems like `toUnit()` is causing rounding errors and returns `1222643699` instead of `1222643700` sometimes.