### PR TITLE
Run garbage collection after each symlink and expose --gc in tart prune

### DIFF
--- a/Sources/tart/Commands/Prune.swift
+++ b/Sources/tart/Commands/Prune.swift
@@ -16,6 +16,9 @@ struct Prune: AsyncParsableCommand {
     valueName: "n"))
   var cacheBudget: UInt?
 
+  @Flag(help: .hidden)
+  var gc: Bool = false
+
   func validate() throws {
     if olderThan == nil && cacheBudget == nil {
       throw ValidationError("at least one criteria must be specified")
@@ -24,6 +27,10 @@ struct Prune: AsyncParsableCommand {
 
   func run() async throws {
     do {
+      if gc {
+        try VMStorageOCI().gc()
+      }
+
       // Clean up cache entries based on last accessed date
       if let olderThan = olderThan {
         let olderThanInterval = Int(exactly: olderThan)!.days.timeInterval

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -166,6 +166,8 @@ class VMStorageOCI: PrunableStorage {
     }
 
     try FileManager.default.createSymbolicLink(at: vmURL(to), withDestinationURL: vmURL(from))
+
+    try gc()
   }
 }
 


### PR DESCRIPTION
This way when pulling the same image `ghcr.io/cirruslabs/macos-monterey-base:latest` over and over across it's lifetime we won't end up with a bunch of old images occupying the space on disk.

Also add hidden `tart prune --gc` flag to fix this manually.