### PR TITLE
Credential helpers: "credHelpers" map is optional in Docker's config

### DIFF
--- a/Sources/tart/Credentials/HelperProgramCredentialsProvider.swift
+++ b/Sources/tart/Credentials/HelperProgramCredentialsProvider.swift
@@ -7,8 +7,8 @@ class HelperProgramCredentialsProvider: CredentialsProvider {
       return nil
     }
     let config = try JSONDecoder().decode(DockerConfig.self, from: Data(contentsOf: dockerConfigURL))
-    
-    if let helperProgram = config.credHelpers[host] {
+
+    if let helperProgram = config.credHelpers?[host] {
       return try executeHelper(binaryName: "docker-credential-\(helperProgram)", host: host)
     }
 
@@ -54,7 +54,7 @@ class HelperProgramCredentialsProvider: CredentialsProvider {
 }
 
 struct DockerConfig: Codable {
-  var credHelpers: Dictionary<String, String> = Dictionary()
+  var credHelpers: Dictionary<String, String>? = Dictionary()
 }
 
 struct DockerGetOutput: Codable {


### PR DESCRIPTION
Otherwise we get the following error:

```
% tart pull ghcr.io/cirruslabs/macos-monterey-vanilla:12.4
pulling ghcr.io/cirruslabs/macos-monterey-vanilla:12.4...
pulling manifest...
keyNotFound(CodingKeys(stringValue: "credHelpers", intValue: nil), Swift.DecodingError.Context(codingPath: [], debugDescription: "No value associated with key CodingKeys(stringValue: \"credHelpers\", intValue: nil) (\"credHelpers\").", underlyingError: nil))
```

With the following `~/.docker/config.json`:

```json
{
  "auths": {
    "ghcr.io": {},
    "registry.gitlab.com": {}
  },
  "credsStore": "desktop"
}
```