### PR TITLE
Terminate VM on GUI window close

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -148,6 +148,8 @@ struct Run: AsyncParsableCommand {
           Group {
             VMView(vm: vm!).onAppear {
               NSWindow.allowsAutomaticWindowTabbing = false
+            }.onDisappear {
+              NSApplication.shared.terminate(self)
             }
           }.frame(width: CGFloat(vm!.config.display.width), height: CGFloat(vm!.config.display.height))
         }.commands {


### PR DESCRIPTION
I've tested `requestStop()` and it seems to be largely useless, because of this:

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/85709/187303821-4ca9d8f6-8d7f-4e56-90dc-82f9ab598e85.png">

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/85709/187303732-1c9541df-962f-4ecf-b6b5-be63485882ce.png">

Resolves https://github.com/cirruslabs/tart/issues/204.