### PR TITLE
tart clone: clone VM and generate MAC under a file lock

### DIFF
--- a/Sources/tart/Config.swift
+++ b/Sources/tart/Config.swift
@@ -4,7 +4,7 @@ struct Config {
   let tartHomeDir: URL
   let tartCacheDir: URL
 
-  init() {
+  init() throws {
     var tartHomeDir: URL
 
     if let customTartHome = ProcessInfo.processInfo.environment["TART_HOME"] {
@@ -17,6 +17,8 @@ struct Config {
 
     self.tartHomeDir = tartHomeDir
     tartCacheDir = tartHomeDir.appendingPathComponent("cache", isDirectory: true)
+
+    try FileManager.default.createDirectory(at: tartCacheDir, withIntermediateDirectories: true)
   }
 
   static func jsonEncoder() -> JSONEncoder {

--- a/Sources/tart/FileLock.swift
+++ b/Sources/tart/FileLock.swift
@@ -1,0 +1,46 @@
+import Foundation
+import System
+
+enum FileLockError: Error, Equatable {
+    case Failed(_ message: String)
+    case AlreadyLocked
+}
+
+class FileLock {
+    let url: URL
+    let fh: FileHandle
+
+    init(lockURL: URL) throws {
+        url = lockURL
+        fh = try FileHandle(forWritingTo: lockURL)
+    }
+
+    deinit {
+        try! fh.close()
+    }
+
+    func trylock() throws {
+        try flockWrapper(LOCK_EX | LOCK_NB)
+    }
+
+    func lock() throws {
+        try flockWrapper(LOCK_EX)
+    }
+
+    func unlock() throws {
+        try flockWrapper(LOCK_UN)
+    }
+
+    func flockWrapper(_ operation: Int32) throws {
+        let ret = flock(fh.fileDescriptor, operation)
+        if ret != 0 {
+            let details = Errno(rawValue: CInt(errno))
+
+            if (operation & LOCK_NB) != 0 && details == .wouldBlock {
+                throw FileLockError.AlreadyLocked
+            }
+
+            throw FileLockError.Failed("failed to lock \(url): \(details)")
+        }
+    }
+}

--- a/Sources/tart/IPSWCache.swift
+++ b/Sources/tart/IPSWCache.swift
@@ -5,7 +5,7 @@ class IPSWCache: PrunableStorage {
   let baseURL: URL
 
   init() throws {
-    baseURL = Config().tartCacheDir.appendingPathComponent("IPSWs", isDirectory: true)
+    baseURL = try Config().tartCacheDir.appendingPathComponent("IPSWs", isDirectory: true)
     try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
   }
 

--- a/Sources/tart/VMStorageLocal.swift
+++ b/Sources/tart/VMStorageLocal.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class VMStorageLocal {
-  let baseURL: URL = Config().tartHomeDir.appendingPathComponent("vms", isDirectory: true)
+  let baseURL: URL = try! Config().tartHomeDir.appendingPathComponent("vms", isDirectory: true)
 
   private func vmURL(_ name: String) -> URL {
     baseURL.appendingPathComponent(name, isDirectory: true)

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class VMStorageOCI: PrunableStorage {
-  let baseURL = Config().tartCacheDir.appendingPathComponent("OCIs", isDirectory: true)
+  let baseURL = try! Config().tartCacheDir.appendingPathComponent("OCIs", isDirectory: true)
 
   private func vmURL(_ name: RemoteName) -> URL {
     baseURL.appendingRemoteName(name)

--- a/Tests/TartTests/FileLockTests.swift
+++ b/Tests/TartTests/FileLockTests.swift
@@ -21,9 +21,7 @@ final class FileLockTests: XCTestCase {
         try firstLock.lock()
 
         let secondLock = try! FileLock(lockURL: url)
-        XCTAssertThrowsError(try secondLock.trylock()) { error in
-            XCTAssertEqual(error as! FileLockError, FileLockError.AlreadyLocked)
-        }
+        XCTAssertFalse(try secondLock.trylock())
     }
 
     private func temporaryFile() -> URL {

--- a/Tests/TartTests/FileLockTests.swift
+++ b/Tests/TartTests/FileLockTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import tart
+
+final class FileLockTests: XCTestCase {
+    func testSimple() throws {
+        // Create a temporary file that will be used as a lock
+        let url = temporaryFile()
+
+        // Make sure this file can be locked and unlocked
+        let lock = try FileLock(lockURL: url)
+        try lock.lock()
+        try lock.unlock()
+    }
+
+    func testDoubleLockResultsInError() throws {
+        // Create a temporary file that will be used as a lock
+        let url = temporaryFile()
+
+        // Create two locks on a same file and ensure one of them fails
+        let firstLock = try FileLock(lockURL: url)
+        try firstLock.lock()
+
+        let secondLock = try! FileLock(lockURL: url)
+        XCTAssertThrowsError(try secondLock.trylock()) { error in
+            XCTAssertEqual(error as! FileLockError, FileLockError.AlreadyLocked)
+        }
+    }
+
+    private func temporaryFile() -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+
+        return url
+    }
+}


### PR DESCRIPTION
Otherwise there exists a race condition that might result in two parallel `tart clone` instances creating two VMs with a similar MAC addresses.