### PR TITLE
Clarify if guest or host is unsupported

### DIFF
--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -14,7 +14,7 @@ struct UnsupportedOSError: Error, CustomStringConvertible {
   let description: String
 
   init(_ what: String, _ plural: String) {
-    description = "error: \(what) \(plural) only supported on macOS 13.0 (Ventura) or newer"
+    description = "error: \(what) \(plural) only supported on hosts running macOS 13.0 (Ventura) or newer"
   }
 }
 


### PR DESCRIPTION

Whilst attempting to use the directory share support, I encountered:  
`Error: error: directory sharing is only supported on macOS 13.0 (Ventura) or newer`

From that message it wasn't abundantly clear if it was my host or my guest that was not running the supported version of macOS