### PR TITLE
Clarify requirements for `dir` argument

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -47,8 +47,10 @@ struct Run: AsyncParsableCommand {
   @Option(help: ArgumentHelp("""
                              Additional directory shares with an optional read-only specifier\n(e.g. --dir=\"build:~/src/build\" --dir=\"sources:~/src/sources:ro\")
                              """, discussion: """
+                                              Requires host to be macOS 13.0 (Ventura) or newer.
                                               All shared directories are automatically mounted to "/Volumes/My Shared Files" directory on macOS,
                                               while on Linux you have to do it manually: "mount -t virtiofs com.apple.virtio-fs.automount /mount/point".
+                                              For macOS guests, they must be running macOS 13.0 (Ventura) or newer.
                                               """, valueName: "name:path[:ro]"))
   var dir: [String] = []
 


### PR DESCRIPTION
Follow on from https://github.com/cirruslabs/tart/pull/228

It is unclear when using the `dir` directory sharing that it requires guests to be running macOS 13 also. This PR tries to clarify that requirement in the help discussion output. 

Is there a way to read back out from the VM either running or prior to booting to know the version macOS? Would be nicer to report the failure as opposed to requiring the user read the docs. 