### PR TITLE
Handle tilde in path for directory share

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -166,7 +166,7 @@ struct Run: AsyncParsableCommand {
 
       let (name, path) = (String(splits[0]), String(splits[1]))
 
-      result.append(DirectoryShare(name: name, path: URL(fileURLWithPath: path), readOnly: readOnly))
+      result.append(DirectoryShare(name: name, path: URL(fileURLWithPath: NSString(string: path).expandingTildeInPath), readOnly: readOnly))
     }
 
     return result

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -126,8 +126,9 @@ struct Run: AsyncParsableCommand {
   func additionalDiskAttachments() throws -> [VZDiskImageStorageDeviceAttachment] {
     var result: [VZDiskImageStorageDeviceAttachment] = []
     let readOnlySuffix = ":ro"
+    let expandedDiskPaths = disk.map { NSString(string:$0).expandingTildeInPath }
 
-    for rawDisk in disk {
+    for rawDisk in expandedDiskPaths {
       if rawDisk.hasSuffix(readOnlySuffix) {
         result.append(try VZDiskImageStorageDeviceAttachment(
           url: URL(fileURLWithPath: String(rawDisk.prefix(rawDisk.count - readOnlySuffix.count))),


### PR DESCRIPTION
See https://github.com/cirruslabs/tart/issues/232

If you create a `URL` such as  `URL(fileURLWithPath: "~/Downloads")` it doesn't automatically expand the tilde into the home directory. 

This PR uses NSString's `expandingTildeInPath` api to do the heavy lifting. 

Ideally `VZVirtualMachine` wouldn't hang and instead log if the directory share paths given didn't exist. 