### PR TITLE
[skip ci] Add sponsorship option

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [cirruslabs]

--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ This invocation calls the `tart pull` implicitly (if the image is not being pres
 <details>
   <summary>Why Tart is free and open sourced?</summary>
 
-  Tart is a relatively small project, and it didn't feel right to try to monetize it.
-  Apple did all the heavy lifting with their `Virtualization.Framework`.
+  Apple did all the heavy lifting with their `Virtualization.Framework` and it just felt right to develop Tart in the open.
+  Please consider [becoming a sponsor](https://github.com/sponsors/cirruslabs) if you find Tart saving a substantial amount of money on licensing and engineering hours for your company.
 </details>
 
 <details>


### PR DESCRIPTION
Tart is becoming more and more complex project... Plus it saves tens of thousands of dollars in licensing comparing to the old proprietary solutions. Let's add a totally optional way to sponsor Tart's development.