### PR TITLE
Revert com.apple.vm.networking entitlement

### DIFF
--- a/Resources/tart.entitlements
+++ b/Resources/tart.entitlements
@@ -4,7 +4,5 @@
 <dict>
 	<key>com.apple.security.virtualization</key>
 	<true/>
-	<key>com.apple.vm.networking</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
While we figure out what's wrong with the `com.apple.vm.networking`.