### PR TITLE
Fixed wait delay for IP command

### DIFF
--- a/Sources/tart/Commands/IP.swift
+++ b/Sources/tart/Commands/IP.swift
@@ -47,8 +47,9 @@ struct IP: AsyncParsableCommand {
       if let ip = try Leases().resolveMACAddress(macAddress: vmMACAddress) {
         return ip
       }
-
-      try await Task.sleep(nanoseconds: 1_000_000)
+      
+      // wait a second
+      try await Task.sleep(nanoseconds: 1_000_000_000)
     } while Date.now < waitUntil
 
     return nil


### PR DESCRIPTION
I initially wanted a one-second wait but made a human mistake.

Fixes #249