### PR TITLE
Fix tart prune --cache-budget logic

### DIFF
--- a/Sources/tart/Commands/Prune.swift
+++ b/Sources/tart/Commands/Prune.swift
@@ -72,8 +72,11 @@ struct Prune: AsyncParsableCommand {
       let prunableSizeBytes = UInt64(try prunable.sizeBytes())
 
       if prunableSizeBytes <= cacheBudgetBytes {
+        // Don't mark for deletion as
+        // there's a budget available
         cacheBudgetBytes -= prunableSizeBytes
       } else {
+        // Mark for deletion
         prunablesToDelete.append(prunable)
       }
     }


### PR DESCRIPTION
We now try to gather as much of the recent cache entries as possible that fit the budget before deleting the rest.

Resolves https://github.com/cirruslabs/tart/issues/271.