### PR TITLE
Implement Get command

### DIFF
--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -13,12 +13,13 @@ struct Get: AsyncParsableCommand {
       let vmConfig = try VMConfig(fromURL: vmDir.configURL)
       let diskSize = try vmDir.sizeBytes() / 1024 / 1024 / 1000
 
-      print("""
-            cpu cores: \(vmConfig.cpuCount)
-            memory:    \(vmConfig.memorySize / 1024 / 1024)
-            disk size: \(diskSize) GB
-            display:   \(vmConfig.display.width) x \(vmConfig.display.height)
-            """)
+      print("cpu\tmemory\tdisk\tdisplay")
+
+      var s = "\(vmConfig.cpuCount)\t"
+      s += "\(vmConfig.memorySize / 1024 / 1024)MB\t"
+      s += "\(diskSize)GB\t"
+      s += "\(vmConfig.display.width)x\(vmConfig.display.height)"
+      print(s)
 
       Foundation.exit(0)
     } catch {

--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -13,7 +13,7 @@ struct Get: AsyncParsableCommand {
       let vmConfig = try VMConfig(fromURL: vmDir.configURL)
       let diskSize = try vmDir.sizeBytes() / 1024 / 1024 / 1000
 
-      print("cpu\tmemory\tdisk\tdisplay")
+      print("CPU\tMemory\tDisk\tDisplay")
 
       var s = "\(vmConfig.cpuCount)\t"
       s += "\(vmConfig.memorySize / 1024 / 1024)MB\t"

--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -1,0 +1,30 @@
+import ArgumentParser
+import Foundation
+
+struct Get: AsyncParsableCommand {
+  static var configuration = CommandConfiguration(commandName: "get", abstract: "Get a VM's configuration")
+
+  @Argument(help: "VM name")
+  var name: String
+
+  func run() async throws {
+    do {
+      let vmDir = try VMStorageLocal().open(name)
+      let vmConfig = try VMConfig(fromURL: vmDir.configURL)
+      let diskSize = try vmDir.sizeBytes() / 1024 / 1024 / 1000
+
+      print("""
+            cpu cores: \(vmConfig.cpuCount)
+            memory:    \(vmConfig.memorySize / 1024 / 1024)
+            disk size: \(diskSize) GB
+            display:   \(vmConfig.display.width) x \(vmConfig.display.height)
+            """)
+
+      Foundation.exit(0)
+    } catch {
+      print(error)
+
+      Foundation.exit(1)
+    }
+  }
+}

--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -11,13 +11,13 @@ struct Get: AsyncParsableCommand {
     do {
       let vmDir = try VMStorageLocal().open(name)
       let vmConfig = try VMConfig(fromURL: vmDir.configURL)
-      let diskSize = try vmDir.sizeBytes() / 1024 / 1024 / 1000
+      let diskSize = try vmDir.sizeBytes() / 1000 / 1000 / 1000
 
       print("CPU\tMemory\tDisk\tDisplay")
 
       var s = "\(vmConfig.cpuCount)\t"
-      s += "\(vmConfig.memorySize / 1024 / 1024)MB\t"
-      s += "\(diskSize)GB\t"
+      s += "\(vmConfig.memorySize / 1024 / 1024) MB\t"
+      s += "\(diskSize) GB\t"
       s += "\(vmConfig.display.width)x\(vmConfig.display.height)"
       print(s)
 

--- a/Sources/tart/Root.swift
+++ b/Sources/tart/Root.swift
@@ -20,6 +20,7 @@ struct Root: AsyncParsableCommand {
       Clone.self,
       Run.self,
       Set.self,
+      Get.self,
       List.self,
       Login.self,
       IP.self,


### PR DESCRIPTION
This PR implements a get command as outlined in https://github.com/cirruslabs/tart/issues/302. The output was formatted to look similar to other `tart` commands and is as follows:

```
> tart get m
cpu     memory  disk    display
4       8192MB  20GB    1024x768
```