### PR TITLE
Fixed Tart logo on GitHubMobile App

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Tart – open source virtualization for your automation needs](Resources/TartSocial.png)
+<img src="https://github.com/cirruslabs/tart/raw/main/Resources/TartSocial.png"/>
 
 *Tart* is a virtualization toolset to build, run and manage macOS and Linux virtual machines on Apple Silicon.
 Built by CI engineers for your automation needs. Here are some highlights of Tart:


### PR DESCRIPTION
We can't use the regular images since we use Git LFS. Forgot to fix the main image as part of #237