### PR TITLE
Fetch IPSWs via file

### DIFF
--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -63,7 +63,7 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
 
   static func retrieveIPSW(remoteURL: URL) async throws -> URL {
     // Check if we already have this IPSW in cache
-    let (channel, response) = try await Fetcher.fetch(URLRequest(url: remoteURL))
+    let (channel, response) = try await Fetcher.fetch(URLRequest(url: remoteURL), viaFile: true)
 
     if let hash = response.value(forHTTPHeaderField: "x-amz-meta-digest-sha256") {
       let ipswLocation = try IPSWCache().locationFor(fileName: "sha256:\(hash).ipsw")


### PR DESCRIPTION
Otherwise the memory usage is too high. This is also what causing the integration tests to fail: https://cirrus-ci.com/task/4605565639852032.