### PR TITLE
Filter tart list by source

### DIFF
--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -7,7 +7,7 @@ struct List: AsyncParsableCommand {
 
   @Flag(name: [.short, .long], help: ArgumentHelp("Only display VM names."))
   var quiet: Bool = false
-  
+
   @Option(name: [.short, .long], help: ArgumentHelp("Only display VMs of this Source."))
   var source: String = ""
 
@@ -24,7 +24,7 @@ struct List: AsyncParsableCommand {
       default:
         throw ValidationError("Unknown source: '\(source)'")
       }
-      
+
       Foundation.exit(0)
     } catch {
       print(error)
@@ -37,7 +37,7 @@ struct List: AsyncParsableCommand {
     if !quiet {
       print("Source\tName")
     }
-    
+
     for (name, _) in vms.sorted(by: { left, right in left.0 < right.0 }) {
       if quiet {
         print(name)

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -5,18 +5,30 @@ import SwiftUI
 struct List: AsyncParsableCommand {
   static var configuration = CommandConfiguration(abstract: "List created VMs")
 
-  @Flag(name: [.short, .long], help: ArgumentHelp("Only display VM names"))
+  @Flag(name: [.short, .long], help: ArgumentHelp("Only display VM names."))
   var quiet: Bool = false
+  
+  @Option(name: [.short, .long], help: ArgumentHelp("Only display VMs of this Source."))
+  var source: String = ""
 
   func run() async throws {
     do {
       if !quiet {
         print("Source\tName")
       }
-
-      displayTable("local", try VMStorageLocal().list())
-      displayTable("oci", try VMStorageOCI().list().map { (name, vmDir, _) in (name, vmDir) })
-
+      
+      switch source {
+      case "local":
+        displayTable("local", try VMStorageLocal().list())
+      case "oci":
+        displayTable("oci", try VMStorageOCI().list().map { (name, vmDir, _) in (name, vmDir) })
+      case "":
+        displayTable("local", try VMStorageLocal().list())
+        displayTable("oci", try VMStorageOCI().list().map { (name, vmDir, _) in (name, vmDir) })
+      default:
+        throw ValidationError("Unknown source: '\(source)'")
+      }
+      
       Foundation.exit(0)
     } catch {
       print(error)

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -8,7 +8,7 @@ struct List: AsyncParsableCommand {
   @Flag(name: [.short, .long], help: ArgumentHelp("Only display VM names."))
   var quiet: Bool = false
 
-  @Option(name: [.short, .long], help: ArgumentHelp("Only display VMs of this Source."))
+  @Option(help: ArgumentHelp("Only display VMs from the specified source (e.g. --source local, --source oci)."))
   var source: String = ""
 
   func run() async throws {

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -42,6 +42,7 @@ struct List: AsyncParsableCommand {
       if quiet {
         print(name)
       } else {
+        let source = source.padding(toLength: "Source".count, withPad: " ", startingAt: 0)
         print("\(source)\t\(name)")
       }
     }

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -13,10 +13,6 @@ struct List: AsyncParsableCommand {
 
   func run() async throws {
     do {
-      if !quiet {
-        print("Source\tName")
-      }
-      
       switch source {
       case "local":
         displayTable("local", try VMStorageLocal().list())
@@ -38,6 +34,10 @@ struct List: AsyncParsableCommand {
   }
 
   private func displayTable(_ source: String, _ vms: [(String, VMDirectory)]) {
+    if !quiet {
+      print("Source\tName")
+    }
+    
     for (name, _) in vms.sorted(by: { left, right in left.0 < right.0 }) {
       if quiet {
         print(name)


### PR DESCRIPTION
An attempt to solve #299 by providing a `--source` option to the `list` command.

Some example output:

```shell
tart list --help                

OVERVIEW: List created VMs

USAGE: tart list [--quiet] [--source <source>]

OPTIONS:
  -q, --quiet             Only display VM names.
  --source <source>       Only display VMs from the specified source (e.g. --source local, --source oci).
  --version               Show the version.
  -h, --help              Show help information.
```

```shell
$ tart list
Source	Name
local 	monterey-base
local 	ventura-base
local 	ventura-new
oci   	ghcr.io/cirruslabs/macos-ventura-base:latest
```

```shell
tart list --source oci
Source  Name
oci   	ghcr.io/cirruslabs/macos-ventura-base:latest
```

```shell
tart list --source foo
Unknown source: 'foo'
```

```shell
tart list --source local --quiet
monterey-base
ventura-base
ventura-new
```

I've made an additional change to tidy up columns in the terminal output.