### PR TITLE
Get command

### DIFF
--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -4,24 +4,24 @@ import Foundation
 struct Get: AsyncParsableCommand {
   static var configuration = CommandConfiguration(commandName: "get", abstract: "Get a VM's configuration")
 
-  @Argument(help: "VM name")
+  @Argument(help: "VM name.")
   var name: String
 
-  @Flag(help: "Number of VM CPUs")
+  @Flag(help: "Number of VM CPUs.")
   var cpu: Bool = false
 
-  @Flag(help: "VM memory size in megabytes")
+  @Flag(help: "VM memory size in megabytes.")
   var memory: Bool = false
 
-  @Flag(help: "Disk size in gigabytes")
+  @Flag(help: "Disk size in gigabytes.")
   var diskSize: Bool = false
 
-  @Flag(help: "VM display resolution in a format of <width>x<height>. For example, 1200x800")
+  @Flag(help: "VM display resolution in a format of <width>x<height>. For example, 1200x800.")
   var display: Bool = false
 
   func validate() throws {
     if [cpu, memory, diskSize, display].filter({$0}).count > 1 {
-      throw ValidationError("--cpu, --memory, --disk-size and --display are mutually exclusive")
+      throw ValidationError("Options --cpu, --memory, --disk-size and --display are mutually exclusive")
     }
   }
 

--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -7,17 +7,46 @@ struct Get: AsyncParsableCommand {
   @Argument(help: "VM name")
   var name: String
 
+  @Flag(help: "Number of VM CPUs")
+  var cpu: Bool = false
+
+  @Flag(help: "VM memory size in megabytes")
+  var memory: Bool = false
+
+  @Flag(help: "Disk size in gigabytes")
+  var diskSize: Bool = false
+
+  @Flag(help: "VM display resolution in a format of <width>x<height>. For example, 1200x800")
+  var display: Bool = false
+
+  func validate() throws {
+    if [cpu, memory, diskSize, display].filter({$0}).count > 1 {
+      throw ValidationError("--cpu, --memory, --disk-size and --display are mutually exclusive")
+    }
+  }
+
   func run() async throws {
     let vmDir = try VMStorageLocal().open(name)
     let vmConfig = try VMConfig(fromURL: vmDir.configURL)
-    let diskSize = try vmDir.sizeBytes() / 1000 / 1000 / 1000
+    let diskSizeInGb = try vmDir.sizeBytes() / 1000 / 1000 / 1000
+    let memorySizeInMb = vmConfig.memorySize  / 1024 / 1024
 
-    print("CPU\tMemory\tDisk\tDisplay")
-
-    var s = "\(vmConfig.cpuCount)\t"
-    s += "\(vmConfig.memorySize / 1024 / 1024) MB\t"
-    s += "\(diskSize) GB\t"
-    s += "\(vmConfig.display.width)x\(vmConfig.display.height)"
-    print(s)
+    if cpu {
+      print(vmConfig.cpuCount)
+    } else if memory {
+      print(memorySizeInMb)
+    } else if diskSize {
+      print(diskSizeInGb)
+    } else if display {
+      print("\(vmConfig.display.width)x\(vmConfig.display.height)")
+    } else {
+      print(
+        "CPU\tMemory\tDisk\tDisplay\n" +
+          "\(vmConfig.cpuCount)\t" +
+          "\(memorySizeInMb) MB\t" +
+          "\(diskSizeInGb) GB\t" +
+          "\(vmConfig.display)"
+      )
+    }
   }
 }

--- a/Sources/tart/VMConfig.swift
+++ b/Sources/tart/VMConfig.swift
@@ -35,6 +35,12 @@ struct VMDisplayConfig: Codable {
   var height: Int = 768
 }
 
+extension VMDisplayConfig: CustomStringConvertible {
+  var description: String {
+    "\(width)x\(height)"
+  }
+}
+
 struct VMConfig: Codable {
   var version: Int = 1
   var os: OS


### PR DESCRIPTION
#302 adds the ability to retrieve individual configuration items via the `get` command.

## Examples:

### Help

```
$tart get monterey-base --help 
OVERVIEW: Get a VM's configuration

USAGE: tart get <name> [--cpu] [--memory] [--disk-size] [--display]

ARGUMENTS:
  <name>                  VM name.

OPTIONS:
  --cpu                   Number of VM CPUs.
  --memory              VM memory size in megabytes.
  --disk-size             Disk size in gigabytes.
  --display               VM display resolution in a format of
                          <width>x<height>. For example, 1200x800.
  --version               Show the version.
  -h, --help              Show help information.
```

### Get CPU

```
$tart get monterey-base --cpu 
4
```

### Error - Get 2 things

```
$tart get monterey-base --cpu --disk-size
Error: Options --cpu, --memory, --disk-size and --display are mutually exclusive
Usage: tart get <name> [--cpu] [--memory] [--disk-size] [--display]
  See 'tart get --help' for more information.
```