### PR TITLE
Don't throw if a VM is not running

### DIFF
--- a/Sources/tart/Commands/Stop.swift
+++ b/Sources/tart/Commands/Stop.swift
@@ -19,7 +19,8 @@ struct Stop: AsyncParsableCommand {
     // Find the VM's PID
     var pid = try lock.pid()
     if pid == 0 {
-      throw RuntimeError("VM \(name) is not running", exitCode: 2)
+      print("VM \"\(name)\" is not running! Nothing to stop!")
+      return
     }
 
     // Try to gracefully terminate the VM


### PR DESCRIPTION
Seems the exit code should be 0 similar to how we allow pull of a local image.