### PR TITLE
Fix ArgumentParser's exception printing

### DIFF
--- a/Sources/tart/Root.swift
+++ b/Sources/tart/Root.swift
@@ -96,21 +96,19 @@ struct Root: AsyncParsableCommand {
         try command.run()
       }
     } catch {
-      if exitCode(for: error).rawValue == 0 {
-        exit(withError: error)
-      }
-
       // Capture the error into Sentry
       SentrySDK.capture(error: error)
       SentrySDK.flush(timeout: 2.seconds.timeInterval)
 
-      print(error)
-
+      // Handle a non-ArgumentParser's exception that requires a specific exit code to be set
       if let errorWithExitCode = error as? HasExitCode {
+        print(error)
+
         Foundation.exit(errorWithExitCode.exitCode)
       }
 
-      Foundation.exit(1)
+      // Handle any other exception, including ArgumentParser's ones
+      exit(withError: error)
     }
   }
 


### PR DESCRIPTION
Before:

```
% tart version
CommandError(commandStack: [tart.Root], parserError: ArgumentParser.ParserError.unexpectedExtraValues([(ArgumentParser.InputOrigin(_elements: Set([ArgumentParser.InputOrigin.Element.argumentIndex(0)])), "version")]))
```

After:

```
% tart version
Error: Unexpected argument 'version'
Usage: tart <subcommand>
  See 'tart --help' for more information.
```