### PR TITLE
Clarify --dir requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ This invocation calls the `tart pull` implicitly (if the image is not being pres
 
 ### Mounting directories
 
-**Note:** macOS 13.0 (Ventura) or newer is required on both the host and guest to mount a directory.
+**Note**: directory mounting is only supported on hosts running macOS 13.0 (Ventura) or newer. macOS guests must also use 13.0 or newer.
 
 To mount a directory, run the VM with the `--dir` argument:
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ This invocation calls the `tart pull` implicitly (if the image is not being pres
 
 ### Mounting directories
 
-To mount a directory, run the VM with the `--dir` argument:
+To mount a directory, run the VM with the `--dir` argument (host must be macOS 13.0 Ventura or newer):
 
 ```shell
 tart run --dir=project:~/src/project vm

--- a/README.md
+++ b/README.md
@@ -278,7 +278,9 @@ This invocation calls the `tart pull` implicitly (if the image is not being pres
 
 ### Mounting directories
 
-To mount a directory, run the VM with the `--dir` argument (host must be macOS 13.0 Ventura or newer):
+**Note:** macOS 13.0 (Ventura) or newer is required on both the host and guest to mount a directory.
+
+To mount a directory, run the VM with the `--dir` argument:
 
 ```shell
 tart run --dir=project:~/src/project vm
@@ -305,8 +307,6 @@ Note that the first parameter in each `--dir` argument must be unique, otherwise
 All shared directories are automatically mounted to `/Volumes/My Shared Files` directory.
 
 The directory we've mounted above will be accessible from the `/Volumes/My Shared Files/project` path inside a guest VM.
-
-Note: to use the directory mounting feature, the guest VM needs to run macOS 13.0 (Ventura) or newer.
 
 #### Accessing mounted directories in Linux guests
 

--- a/README.md
+++ b/README.md
@@ -300,8 +300,6 @@ tart run --dir=www1:~/project1/www --dir=www2:~/project2/www
 
 Note that the first parameter in each `--dir` argument must be unique, otherwise only the last `--dir` argument using that name will be used.
 
-Note: to use the directory mounting feature, the host needs to run macOS 13.0 (Ventura) or newer.
-
 #### Accessing mounted directories in macOS guests
 
 All shared directories are automatically mounted to `/Volumes/My Shared Files` directory.


### PR DESCRIPTION
Since Ventura is pretty new, I think it'd be good to warn people before they download a large image. `tart run --help` gives me this:

```
  --dir <name:path[:ro]>  Additional directory shares with an optional read-only specifier
                          (e.g. --dir="build:~/src/build" --dir="sources:~/src/sources:ro")
        Requires host to be macOS 13.0 (Ventura) or newer.
        All shared directories are automatically mounted to "/Volumes/My Shared Files" directory on macOS,
        while on Linux you have to do it manually: "mount -t virtiofs com.apple.virtio-fs.automount /mount/point".
        For macOS guests, they must be running macOS 13.0 (Ventura) or newer.
```

I'm unclear if `--dir` requires both host and guest to be running Ventura or if the "For macOS guests..." is only talking about the "All shared directories..." portion.