### PR TITLE
Collect installation information

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,10 +39,15 @@ brews:
       name: homebrew-cli
     caveats: See the GitHub repository for more information
     homepage: https://github.com/cirruslabs/tart
+    license: "AGPL-3.0"
     description: Run macOS VMs on Apple Silicon
     skip_upload: auto
     dependencies:
       - "cirruslabs/cli/softnet"
+    post_install: |
+      ENV["SENTRY_DSN"] = "https://606fab64ced94f0991109ac5467e23da@o4504250314522624.ingest.sentry.io/4504606552424448"
+      system "#{bin}/tart report-installation"
+      ENV.delete("SENTRY_DSN")
     custom_block: |
       depends_on :macos => :monterey
       

--- a/Sources/tart/Commands/ReportInstallation.swift
+++ b/Sources/tart/Commands/ReportInstallation.swift
@@ -7,9 +7,9 @@ struct ReportInstallation: AsyncParsableCommand {
     commandName: "report-installation",
     abstract: "Send installation event to Sentry if configured",
     discussion: """
-                Reports macOS version and device model for analytics purposes.
-                Helps Cirrus Labs team to prioritize testing on most popular devices.
-                """,
+    Reports macOS version and device model for analytics purposes.
+    Helps Cirrus Labs team to prioritize testing on most popular devices.
+    """,
     shouldDisplay: false
   )
 

--- a/Sources/tart/Commands/ReportInstallation.swift
+++ b/Sources/tart/Commands/ReportInstallation.swift
@@ -1,0 +1,25 @@
+import ArgumentParser
+import Foundation
+import Sentry
+
+struct ReportInstallation: AsyncParsableCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "report-installation",
+    abstract: "Send installation event to Sentry if configured",
+    discussion: """
+                Reports macOS version and device model for analytics purposes.
+                Helps Cirrus Labs team to prioritize testing on most popular devices.
+                """,
+    shouldDisplay: false
+  )
+
+  func run() async throws {
+    let installationEvent = Event()
+    installationEvent.message = SentryMessage(formatted: "installed")
+    installationEvent.level = SentryLevel.info
+    installationEvent.user = nil
+    installationEvent.stacktrace = nil
+    let id = SentrySDK.capture(event: installationEvent)
+    print("Captured installation event #\(id)!")
+  }
+}

--- a/Sources/tart/Root.swift
+++ b/Sources/tart/Root.swift
@@ -31,6 +31,7 @@ struct Root: AsyncParsableCommand {
       Rename.self,
       Stop.self,
       Delete.self,
+      ReportInstallation.self,
     ])
 
   public static func main() async throws {


### PR DESCRIPTION
Collect macOS version and device model.

The information reported to sentry is pretty anonymous and  doesn't contain information like username, hostname, etc. We are only interested in device model and macOS version.

Fixes #378