### PR TITLE
JSON output for get and list commands

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -116,6 +116,15 @@
         "revision" : "da637c398c5d08896521b737f2868ddc2e7996ae",
         "version" : "0.50.6"
       }
+    },
+    {
+      "identity" : "texttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/cfilipov/TextTable",
+      "state" : {
+        "branch" : "master",
+        "revision" : "e03289289155b4e7aa565e32862f9cb42140596a"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-atomics.git", .upToNextMajor(from: "1.0.0")),
     .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.6"),
     .package(url: "https://github.com/getsentry/sentry-cocoa", from: "7.31.3"),
+    .package(url: "https://github.com/cfilipov/TextTable", branch: "master"),
   ],
   targets: [
     .executableTarget(name: "tart", dependencies: [
@@ -32,7 +33,7 @@ let package = Package(
       .product(name: "Antlr4Static", package: "Antlr4"),
       .product(name: "Atomics", package: "swift-atomics"),
       .product(name: "Sentry", package: "sentry-cocoa"),
-
+      .product(name: "TextTable", package: "TextTable"),
     ], exclude: [
       "OCI/Reference/Makefile",
       "OCI/Reference/Reference.g4",

--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -15,7 +15,7 @@ struct Get: AsyncParsableCommand {
   @Argument(help: "VM name.")
   var name: String
 
-  @Option(help: "Output format")
+  @Option(help: "Output format: text or json")
   var format: Format = .text
 
   func run() async throws {

--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -6,6 +6,7 @@ fileprivate struct VMInfo: Encodable {
   let Memory: UInt64
   let Disk: Int
   let Display: String
+  let Running: Bool
 }
 
 struct Get: AsyncParsableCommand {
@@ -22,8 +23,9 @@ struct Get: AsyncParsableCommand {
     let vmConfig = try VMConfig(fromURL: vmDir.configURL)
     let diskSizeInGb = try vmDir.sizeGB()
     let memorySizeInMb = vmConfig.memorySize / 1024 / 1024
+    let running = try PIDLock(lockURL: vmDir.configURL).pid() > 0
 
-    let info = VMInfo(CPU: vmConfig.cpuCount, Memory: memorySizeInMb, Disk: diskSizeInGb, Display: vmConfig.display.description)
+    let info = VMInfo(CPU: vmConfig.cpuCount, Memory: memorySizeInMb, Disk: diskSizeInGb, Display: vmConfig.display.description, Running: running)
     print(format.renderSingle(data: info))
   }
 }

--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -15,8 +15,8 @@ struct Get: AsyncParsableCommand {
   @Argument(help: "VM name.")
   var name: String
 
-  @Flag(help: "Output format")
-  var format: Format = .table
+  @Option(help: "Output format")
+  var format: Format = .text
 
   func run() async throws {
     let vmDir = try VMStorageLocal().open(name)

--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -26,6 +26,6 @@ struct Get: AsyncParsableCommand {
     let running = try PIDLock(lockURL: vmDir.configURL).pid() > 0
 
     let info = VMInfo(CPU: vmConfig.cpuCount, Memory: memorySizeInMb, Disk: diskSizeInGb, Display: vmConfig.display.description, Running: running)
-    print(format.renderSingle(data: info))
+    print(format.renderSingle(info))
   }
 }

--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -20,7 +20,7 @@ struct Get: AsyncParsableCommand {
   func run() async throws {
     let vmDir = try VMStorageLocal().open(name)
     let vmConfig = try VMConfig(fromURL: vmDir.configURL)
-    let diskSizeInGb = try vmDir.sizeBytes() / 1000 / 1000 / 1000
+    let diskSizeInGb = try vmDir.sizeGB()
     let memorySizeInMb = vmConfig.memorySize / 1024 / 1024
 
     let info = VMInfo(CPU: vmConfig.cpuCount, Memory: memorySizeInMb, Disk: diskSizeInGb, Display: vmConfig.display.description)

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -4,8 +4,8 @@ import SwiftUI
 
 fileprivate struct VMInfo: Encodable {
   let Source: String
-  let Size: Int
   let Name: String
+  let Size: Int
 }
 
 struct List: AsyncParsableCommand {
@@ -31,13 +31,13 @@ struct List: AsyncParsableCommand {
     var infos: [VMInfo] = []
     if source == nil || source == "local" {
       infos += sortedInfos(try VMStorageLocal().list().map { (name, vmDir) in
-        try VMInfo(Source: "local", Size: vmDir.sizeGB(), Name: name)
+        try VMInfo(Source: "local", Name: name, Size: vmDir.sizeGB())
       })
     }
 
     if source == nil || source == "oci" {
       infos += sortedInfos(try VMStorageOCI().list().map { (name, vmDir, _) in
-        try VMInfo(Source: "oci", Size: vmDir.sizeGB(), Name: name)
+        try VMInfo(Source: "oci", Name: name, Size: vmDir.sizeGB())
       })
     }
     print(format.renderList(infos))

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -14,7 +14,7 @@ struct List: AsyncParsableCommand {
   @Option(help: ArgumentHelp("Only display VMs from the specified source (e.g. --source local, --source oci)."))
   var source: String?
 
-  @Option(help: "Output format")
+  @Option(help: "Output format: text or json")
   var format: Format = .text
 
   @Flag(name: [.short, .long], help: ArgumentHelp("Only display VM names."))

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -17,6 +17,9 @@ struct List: AsyncParsableCommand {
   @Option(help: "Output format")
   var format: Format = .text
 
+  @Flag(name: [.short, .long], help: ArgumentHelp("Only display VM names."))
+  var quiet: Bool = false
+
   func validate() throws {
     guard let source = source else {
       return
@@ -40,7 +43,13 @@ struct List: AsyncParsableCommand {
         try VMInfo(Source: "oci", Name: name, Size: vmDir.sizeGB())
       })
     }
-    print(format.renderList(infos))
+    if (quiet) {
+      for info in infos {
+        print(info.Name)
+      }
+    } else {
+      print(format.renderList(infos))
+    }
   }
 
   private func sortedInfos(_ infos: [VMInfo]) -> [VMInfo] {

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -40,7 +40,7 @@ struct List: AsyncParsableCommand {
         try VMInfo(Source: "oci", Size: vmDir.sizeGB(), Name: name)
       })
     }
-    print(format.renderList(data: infos))
+    print(format.renderList(infos))
   }
 
   private func sortedInfos(_ infos: [VMInfo]) -> [VMInfo] {

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -2,14 +2,19 @@ import ArgumentParser
 import Dispatch
 import SwiftUI
 
+fileprivate struct VMInfo: Encodable {
+  let Source: String
+  let Name: String
+}
+
 struct List: AsyncParsableCommand {
   static var configuration = CommandConfiguration(abstract: "List created VMs")
 
-  @Flag(name: [.short, .long], help: ArgumentHelp("Only display VM names."))
-  var quiet: Bool = false
-
   @Option(help: ArgumentHelp("Only display VMs from the specified source (e.g. --source local, --source oci)."))
   var source: String?
+
+  @Flag(help: "Output format")
+  var format: Format = .table
 
   func validate() throws {
     guard let source = source else {
@@ -22,27 +27,22 @@ struct List: AsyncParsableCommand {
   }
 
   func run() async throws {
-    if !quiet {
-      print("Source\tName")
-    }
-
+    var infos: [VMInfo] = []
     if source == nil || source == "local" {
-      displayTable("local", try VMStorageLocal().list())
+      infos += sortedInfos(try VMStorageLocal().list().map { (name, vmDir) in
+        VMInfo(Source: "local", Name: name)
+      })
     }
 
     if source == nil || source == "oci" {
-      displayTable("oci", try VMStorageOCI().list().map { (name, vmDir, _) in (name, vmDir) })
+      infos += sortedInfos(try VMStorageOCI().list().map { (name, vmDir, _) in
+        VMInfo(Source: "oci", Name: name)
+      })
     }
+    print(format.renderList(data: infos))
   }
 
-  private func displayTable(_ source: String, _ vms: [(String, VMDirectory)]) {
-    for (name, _) in vms.sorted(by: { left, right in left.0 < right.0 }) {
-      if quiet {
-        print(name)
-      } else {
-        let source = source.padding(toLength: "Source".count, withPad: " ", startingAt: 0)
-        print("\(source)\t\(name)")
-      }
-    }
+  private func sortedInfos(_ infos: [VMInfo]) -> [VMInfo] {
+    infos.sorted(by: { left, right in left.Name < right.Name })
   }
 }

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -14,8 +14,8 @@ struct List: AsyncParsableCommand {
   @Option(help: ArgumentHelp("Only display VMs from the specified source (e.g. --source local, --source oci)."))
   var source: String?
 
-  @Flag(help: "Output format")
-  var format: Format = .table
+  @Option(help: "Output format")
+  var format: Format = .text
 
   func validate() throws {
     guard let source = source else {

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 fileprivate struct VMInfo: Encodable {
   let Source: String
+  let Size: Int
   let Name: String
 }
 
@@ -30,13 +31,13 @@ struct List: AsyncParsableCommand {
     var infos: [VMInfo] = []
     if source == nil || source == "local" {
       infos += sortedInfos(try VMStorageLocal().list().map { (name, vmDir) in
-        VMInfo(Source: "local", Name: name)
+        try VMInfo(Source: "local", Size: vmDir.sizeGB(), Name: name)
       })
     }
 
     if source == nil || source == "oci" {
       infos += sortedInfos(try VMStorageOCI().list().map { (name, vmDir, _) in
-        VMInfo(Source: "oci", Name: name)
+        try VMInfo(Source: "oci", Size: vmDir.sizeGB(), Name: name)
       })
     }
     print(format.renderList(data: infos))

--- a/Sources/tart/Formatter/Format.swift
+++ b/Sources/tart/Formatter/Format.swift
@@ -31,7 +31,7 @@ enum Format: String, ExpressibleByArgument, CaseIterable {
           return Column(title: fieldName, value: element.value)
         }
       }
-      return table.string(for: data, style: Style.plain) ?? ""
+      return table.string(for: data, style: Style.plain)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     case .json:
       let encoder = JSONEncoder()
       encoder.outputFormatting = .prettyPrinted

--- a/Sources/tart/Formatter/Format.swift
+++ b/Sources/tart/Formatter/Format.swift
@@ -1,0 +1,39 @@
+import ArgumentParser
+import Foundation
+import TextTable
+
+enum Format: String, EnumerableFlag {
+  case table, json
+
+  func renderSingle<T>(data: T) -> String where T: Encodable {
+    switch self {
+    case .table:
+      return renderList(data: [data])
+    case .json:
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = .prettyPrinted
+      return try! encoder.encode(data).asText()
+    }
+  }
+
+  func renderList<T>(data: Array<T>) -> String where T: Encodable {
+    switch self {
+    case .table:
+      if (data.count == 0) {
+        return ""
+      }
+      let table = TextTable<T> { (item: T) in
+        let mirroredObject = Mirror(reflecting: item)
+        return mirroredObject.children.enumerated().map { (_, element) in
+          let fieldName = element.label!
+          return Column(title: fieldName, value: element.value)
+        }
+      }
+      return table.string(for: data, style: Style.plain) ?? ""
+    case .json:
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = .prettyPrinted
+      return try! encoder.encode(data).asText()
+    }
+  }
+}

--- a/Sources/tart/Formatter/Format.swift
+++ b/Sources/tart/Formatter/Format.swift
@@ -4,7 +4,7 @@ import TextTable
 
 enum Format: String, ExpressibleByArgument, CaseIterable {
   case text, json
-  
+
   private(set) static var allValueStrings: [String] = Format.allCases.map { "\($0)"}
 
   func renderSingle<T>(_ data: T) -> String where T: Encodable {

--- a/Sources/tart/Formatter/Format.swift
+++ b/Sources/tart/Formatter/Format.swift
@@ -5,10 +5,10 @@ import TextTable
 enum Format: String, EnumerableFlag {
   case table, json
 
-  func renderSingle<T>(data: T) -> String where T: Encodable {
+  func renderSingle<T>(_ data: T) -> String where T: Encodable {
     switch self {
     case .table:
-      return renderList(data: [data])
+      return renderList([data])
     case .json:
       let encoder = JSONEncoder()
       encoder.outputFormatting = .prettyPrinted
@@ -16,7 +16,7 @@ enum Format: String, EnumerableFlag {
     }
   }
 
-  func renderList<T>(data: Array<T>) -> String where T: Encodable {
+  func renderList<T>(_ data: Array<T>) -> String where T: Encodable {
     switch self {
     case .table:
       if (data.count == 0) {

--- a/Sources/tart/Formatter/Format.swift
+++ b/Sources/tart/Formatter/Format.swift
@@ -2,12 +2,12 @@ import ArgumentParser
 import Foundation
 import TextTable
 
-enum Format: String, EnumerableFlag {
-  case table, json
+enum Format: String, ExpressibleByArgument {
+  case text, json
 
   func renderSingle<T>(_ data: T) -> String where T: Encodable {
     switch self {
-    case .table:
+    case .text:
       return renderList([data])
     case .json:
       let encoder = JSONEncoder()
@@ -18,7 +18,7 @@ enum Format: String, EnumerableFlag {
 
   func renderList<T>(_ data: Array<T>) -> String where T: Encodable {
     switch self {
-    case .table:
+    case .text:
       if (data.count == 0) {
         return ""
       }

--- a/Sources/tart/Formatter/Format.swift
+++ b/Sources/tart/Formatter/Format.swift
@@ -2,8 +2,10 @@ import ArgumentParser
 import Foundation
 import TextTable
 
-enum Format: String, ExpressibleByArgument {
+enum Format: String, ExpressibleByArgument, CaseIterable {
   case text, json
+  
+  private(set) static var allValueStrings: [String] = Format.allCases.map { "\($0)"}
 
   func renderSingle<T>(_ data: T) -> String where T: Encodable {
     switch self {

--- a/Sources/tart/VMDirectory.swift
+++ b/Sources/tart/VMDirectory.swift
@@ -107,6 +107,10 @@ struct VMDirectory: Prunable {
     try configURL.sizeBytes() + diskURL.sizeBytes() + nvramURL.sizeBytes()
   }
 
+  func sizeGB() throws -> Int {
+    try sizeBytes() / 1000 / 1000 / 1000
+  }
+
   func markExplicitlyPulled() {
     FileManager.default.createFile(atPath: explicitlyPulledMark.path, contents: nil)
   }


### PR DESCRIPTION
In the light of the upcoming `1.0.0` release and stabilizing of the API, let's introduce some breaking changes for the good.

Removed all the `--cpu`, `--memory`, `--disk` and `--display` flags and replaced with a single `--json` flag for machine-readable output.

Added `--json` option to the `list` command to output a single JSON list. Notably removed `--quite` flag since it seemed unnecessary.

Fixes #297