### PR TITLE
Avoid URL.formatted() method

### DIFF
--- a/Sources/tart/Commands/Prune.swift
+++ b/Sources/tart/Commands/Prune.swift
@@ -101,7 +101,7 @@ struct Prune: AsyncParsableCommand {
       cacheReclaimedBytes += try prunable.sizeBytes()
       try prunable.delete()
 
-      try SentrySDK.span?.setExtra(value: prunable.sizeBytes(), key: prunable.url.formatted());
+      try SentrySDK.span?.setExtra(value: prunable.sizeBytes(), key: prunable.url.path);
     }
 
     SentrySDK.span?.setMeasurement(name: "gc_disk_reclaimed", value: cacheReclaimedBytes as NSNumber, unit: MeasurementUnitInformation.byte);


### PR DESCRIPTION
This method is not marked as macOS 13.0+ only in the SDK for some reason, but is marked so [in the documentation](https://developer.apple.com/documentation/foundation/url/4013498-formatted).

Resolves https://github.com/cirruslabs/tart/issues/407.