### PR TITLE
Build Package installer and notarize release archive

### DIFF
--- a/.ci/create-pkg.sh
+++ b/.ci/create-pkg.sh
@@ -4,7 +4,7 @@ set -e
 
 export VERSION="${CIRRUS_TAG:-0}"
 
-mkdir -p .ci/pkg/Tart.app/Contents/MacOS
+mkdir -p .ci/pkg/tart.app/Contents/MacOS
 cp .build/arm64-apple-macosx/debug/tart .ci/pkg/tart.app/Contents/MacOS/tart
 cp Resources/embedded.provisionprofile .ci/pkg/tart.app/Contents/embedded.provisionprofile
 pkgbuild --root .ci/pkg/ --identifier com.github.cirruslabs.tart --version $VERSION \

--- a/.ci/create-pkg.sh
+++ b/.ci/create-pkg.sh
@@ -7,9 +7,9 @@ export VERSION="${CIRRUS_TAG:-0}"
 mkdir -p .ci/pkg/Tart.app/Contents/MacOS
 cp .build/arm64-apple-macosx/debug/tart .ci/pkg/Tart.app/Contents/MacOS/Tart
 cp Resources/embedded.provisionprofile .ci/pkg/Tart.app/Contents/embedded.provisionprofile
-pkgbuild --root .ci/pkg/Tart.app --identifier com.github.cirruslabs.tart --version $VERSION \
+pkgbuild --root .ci/pkg/ --identifier com.github.cirruslabs.tart --version $VERSION \
   --scripts .ci/pkg/scripts \
-  --install-location "/Library/Application Support/Tart/Tart.app" \
+  --install-location "/Library/Application Support/Tart" \
   --sign "Developer ID Installer: Cirrus Labs, Inc. (9M2P8L4D89)" \
   "./.ci/Tart-$VERSION.pkg"
 xcrun notarytool submit "./.ci/Tart-$VERSION.pkg" --keychain-profile "notarytool" --wait

--- a/.ci/create-pkg.sh
+++ b/.ci/create-pkg.sh
@@ -4,9 +4,9 @@ set -e
 
 export VERSION="${CIRRUS_TAG:-0}"
 
-mkdir -p .ci/pkg/tart.app/Contents/MacOS
-cp .build/arm64-apple-macosx/debug/tart .ci/pkg/tart.app/Contents/MacOS/tart
-cp Resources/embedded.provisionprofile .ci/pkg/tart.app/Contents/embedded.provisionprofile
+mkdir -p .ci/pkg/
+cp .build/arm64-apple-macosx/debug/tart .ci/pkg/tart
+cp Resources/embedded.provisionprofile .ci/pkg/embedded.provisionprofile
 pkgbuild --root .ci/pkg/ --identifier com.github.cirruslabs.tart --version $VERSION \
   --scripts .ci/pkg/scripts \
   --install-location "/Library/Application Support/Tart" \

--- a/.ci/create-pkg.sh
+++ b/.ci/create-pkg.sh
@@ -5,8 +5,8 @@ set -e
 export VERSION="${CIRRUS_TAG:-0}"
 
 mkdir -p .ci/pkg/Tart.app/Contents/MacOS
-cp .build/arm64-apple-macosx/debug/tart .ci/pkg/Tart.app/Contents/MacOS/Tart
-cp Resources/embedded.provisionprofile .ci/pkg/Tart.app/Contents/embedded.provisionprofile
+cp .build/arm64-apple-macosx/debug/tart .ci/pkg/tart.app/Contents/MacOS/tart
+cp Resources/embedded.provisionprofile .ci/pkg/tart.app/Contents/embedded.provisionprofile
 pkgbuild --root .ci/pkg/ --identifier com.github.cirruslabs.tart --version $VERSION \
   --scripts .ci/pkg/scripts \
   --install-location "/Library/Application Support/Tart" \

--- a/.ci/pkg/scripts/postinstall
+++ b/.ci/pkg/scripts/postinstall
@@ -3,6 +3,6 @@
 set -e
 
 echo "#!/bin/sh" > /usr/local/bin/tart
-echo "exec '$2/Contents/MacOS/Tart' \"\$@\"" >> /usr/local/bin/tart
+echo "exec '$2/Tart.app/Contents/MacOS/Tart' \"\$@\"" >> /usr/local/bin/tart
 
 chmod +x /usr/local/bin/tart

--- a/.ci/pkg/scripts/postinstall
+++ b/.ci/pkg/scripts/postinstall
@@ -2,6 +2,11 @@
 
 set -e
 
+# fix structure
+mkdir -p "$2/tart.app/Contents/MacOS"
+mv "$2/tart" "$2/tart.app/Contents/MacOS/tart"
+mv "$2/embedded.provisionprofile" "$2/tart.app/Contents/embedded.provisionprofile"
+
 echo "#!/bin/sh" > /usr/local/bin/tart
 echo "exec '$2/tart.app/Contents/MacOS/tart' \"\$@\"" >> /usr/local/bin/tart
 

--- a/.ci/pkg/scripts/postinstall
+++ b/.ci/pkg/scripts/postinstall
@@ -3,6 +3,6 @@
 set -e
 
 echo "#!/bin/sh" > /usr/local/bin/tart
-echo "exec '$2/Tart.app/Contents/MacOS/Tart' \"\$@\"" >> /usr/local/bin/tart
+echo "exec '$2/tart.app/Contents/MacOS/tart' \"\$@\"" >> /usr/local/bin/tart
 
 chmod +x /usr/local/bin/tart

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,7 +76,7 @@ task:
     - security find-identity -v
     - xcodebuild -version
     - swift -version
-  release_script: goreleaser release --skip-publish --snapshot --clean
+  goreleaser_script: goreleaser release --skip-publish --snapshot --clean
   always:
     release_artifacts:
       path: "dist/*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,8 +77,9 @@ task:
     - xcodebuild -version
     - swift -version
   release_script: goreleaser release --skip-publish --snapshot --clean
-  dist_artifacts:
-    path: "dist/*"
+  always:
+    dist_artifacts:
+      path: "dist/*"
 
 task:
   name: Release

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,6 +48,39 @@ task:
     path: .build/debug/tart
 
 task:
+  name: Release (Dry Run)
+  only_if: $CIRRUS_TAG == '' && ($CIRRUS_USER_PERMISSIONS == 'write' || $CIRRUS_USER_PERMISSIONS == 'admin')
+  depends_on:
+    - lint
+    - build
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-xcode:latest
+  env:
+    MACOS_CERTIFICATE: ENCRYPTED[552b9d275d1c2bdbc1bff778b104a8f9a53cbd0d59344d4b7f6d0ca3c811a5cefb97bef9ba0ef31c219cb07bdacdd2c2]
+    AC_PASSWORD: ENCRYPTED[4a761023e7e06fe2eb350c8b6e8e7ca961af193cb9ba47605f25f1d353abc3142606f412e405be48fd897a78787ea8c2]
+    GITHUB_TOKEN: ENCRYPTED[!98ace8259c6024da912c14d5a3c5c6aac186890a8d4819fad78f3e0c41a4e0cd3a2537dd6e91493952fb056fa434be7c!]
+    GORELEASER_KEY: ENCRYPTED[!9b80b6ef684ceaf40edd4c7af93014ee156c8aba7e6e5795f41c482729887b5c31f36b651491d790f1f668670888d9fd!]
+  setup_script:
+    - cd $HOME
+    - echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+    - security create-keychain -p password101 build.keychain
+    - security default-keychain -s build.keychain
+    - security unlock-keychain -p password101 build.keychain
+    - security import certificate.p12 -k build.keychain -P password101 -T /usr/bin/codesign -T /usr/bin/pkgbuild
+    - security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k password101 build.keychain
+    - xcrun notarytool store-credentials "notarytool" --apple-id "hello@cirruslabs.org" --team-id "9M2P8L4D89" --password $AC_PASSWORD
+  install_script:
+    - brew install go goreleaser/tap/goreleaser-pro getsentry/tools/sentry-cli
+    - brew install mitchellh/gon/gon
+  info_script:
+    - security find-identity -v
+    - xcodebuild -version
+    - swift -version
+  release_script: goreleaser release --skip-publish --snapshot --clean
+  dist_artifacts:
+    path: "dist/*"
+
+task:
   name: Release
   only_if: $CIRRUS_TAG != ''
   depends_on:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,7 +78,7 @@ task:
     - swift -version
   release_script: goreleaser release --skip-publish --snapshot --clean
   always:
-    dist_artifacts:
+    release_artifacts:
       path: "dist/*"
 
 task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,8 +78,10 @@ task:
     - swift -version
   goreleaser_script: goreleaser release --skip-publish --snapshot --clean
   always:
-    release_artifacts:
+    dist_artifacts:
       path: "dist/*"
+    pkg_artifacts:
+      path: ".ci/*.pkg"
 
 task:
   name: Release

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,7 +49,7 @@ task:
 
 task:
   name: Release (Dry Run)
-  only_if: $CIRRUS_TAG == '' && ($CIRRUS_USER_PERMISSIONS == 'write' || $CIRRUS_USER_PERMISSIONS == 'admin')
+  only_if: $CIRRUS_TAG == '' && ($CIRRUS_USER_PERMISSION == 'write' || $CIRRUS_USER_PERMISSION == 'admin')
   depends_on:
     - lint
     - build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,7 @@ builds:
 
 archives:
   - name_template: "{{ .ProjectName }}"
+    format: zip
     files:
       - src: Resources/embedded.provisionprofile
         dst: tart.app/Contents
@@ -29,8 +30,8 @@ archives:
         strip_parent: true
     hooks:
       after:
-        - xcrun notarytool submit "dist/tart.tar.gz" --keychain-profile "notarytool" --wait
-        - xcrun stapler staple "dist/tart.tar.gz"
+        - xcrun notarytool submit "dist/tart.zip" --keychain-profile "notarytool" --wait
+        - xcrun stapler staple "dist/tart.zip"
 
 release:
   prerelease: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,10 +23,6 @@ archives:
     format: zip
     files:
       - src: Resources/embedded.provisionprofile
-        dst: tart.app/Contents
-        strip_parent: true
-      - src: ".build/arm64-apple-macosx/debug/tart"
-        dst: tart.app/Contents/MacOS
         strip_parent: true
     hooks:
       after:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,8 +47,10 @@ brews:
     dependencies:
       - "cirruslabs/cli/softnet"
     install: |
-      libexec.install Dir["*"]
-      bin.write_exec_script "#{libexec}/Tart.app/Contents/MacOS/tart"
+      mkdir_p libexec/"tart.app/Contents/MacOS/"
+      libexec.install "tart" => "tart.app/Contents/MacOS/tart"
+      libexec.install "embedded.provisionprofile" => "tart.app/Contents/embedded.provisionprofile"
+      bin.write_exec_script "#{libexec}/tart.app/Contents/MacOS/tart"
     custom_block: |
       depends_on :macos => :monterey
       

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,7 @@ before:
   hooks:
     - .ci/set-version.sh
     - swift build -c debug --product tart
+    - gon gon.hcl
 
 builds:
   - builder: prebuilt
@@ -15,7 +16,6 @@ builds:
       path: .build/arm64-apple-macosx/debug/tart 
     hooks:
       post: 
-        - gon gon.hcl
         - ./.ci/create-pkg.sh
 
 archives:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,6 @@ archives:
     hooks:
       after:
         - xcrun notarytool submit "dist/tart.zip" --keychain-profile "notarytool" --wait
-        - xcrun stapler staple "dist/tart.zip"
 
 release:
   prerelease: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,7 @@ builds:
     hooks:
       post: 
         - gon gon.hcl
+        - ./.ci/create-pkg.sh
 
 archives:
   - name_template: "{{ .ProjectName }}"
@@ -29,6 +30,8 @@ archives:
 
 release:
   prerelease: auto
+  extra_files:
+    - glob: ./dist/Tart-{{ .Tag }}.pkg
 
 brews:
   - name: tart

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,10 @@ archives:
       - src: ".build/arm64-apple-macosx/debug/tart"
         dst: tart.app/Contents/MacOS
         strip_parent: true
+    hooks:
+      after:
+        - xcrun notarytool submit "dist/tart.tar.gz" --keychain-profile "notarytool" --wait
+        - xcrun stapler staple "dist/tart.tar.gz"
 
 release:
   prerelease: auto


### PR DESCRIPTION
Build the `*.pkg` again and also notarize the archive uploaded to releases. Notarization tool does not support `*.tar.gz` so I switched to `*.zip` which is supported by both Gorealser and Homebrew.

I also added a Dry Run task that dry runs everything and notarizes everything for contributors with the right permissions.