### PR TITLE
Switch back to .tar.gz

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,13 +20,9 @@ builds:
 
 archives:
   - name_template: "{{ .ProjectName }}"
-    format: zip
     files:
       - src: Resources/embedded.provisionprofile
         strip_parent: true
-    hooks:
-      after:
-        - xcrun notarytool submit "dist/tart.zip" --keychain-profile "notarytool" --wait
 
 release:
   prerelease: auto


### PR DESCRIPTION
Since trying to notarized the release archive as mentioned [here](https://github.com/cirruslabs/tart/pull/415#issuecomment-1450545065) seems breaking the validation.

Fixes #441