### PR TITLE
Upgrade Sentry to 8.3.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "c3c19e29f775ee95b77aa3168f3e2fd6c20deba6",
-        "version" : "7.31.3"
+        "revision" : "ac224c437a3070ffe34460137ac8761eddaf2852",
+        "version" : "8.3.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .package(url: "https://github.com/antlr/antlr4", branch: "dev"),
     .package(url: "https://github.com/apple/swift-atomics.git", .upToNextMajor(from: "1.0.0")),
     .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.6"),
-    .package(url: "https://github.com/getsentry/sentry-cocoa", from: "7.31.3"),
+    .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.3.3"),
     .package(url: "https://github.com/cfilipov/TextTable", branch: "master"),
   ],
   targets: [


### PR DESCRIPTION
This upgrade might improve the quality of Swift stacktraces a bit, see https://github.com/getsentry/sentry-cocoa/releases/tag/8.0.0.

Support for Swift Concurrency is still not implemented, though: https://github.com/getsentry/sentry-cocoa/issues/1919.