### PR TITLE
Build pkg again

### DIFF
--- a/.ci/create-pkg.sh
+++ b/.ci/create-pkg.sh
@@ -7,6 +7,7 @@ export VERSION="${CIRRUS_TAG:-0}"
 mkdir -p .ci/pkg/
 cp .build/arm64-apple-macosx/release/tart .ci/pkg/tart
 codesign --sign "Developer ID Application: Cirrus Labs, Inc. (9M2P8L4D89)" \
+  --options=runtime --deep \
   --entitlements Resources/tart-prod.entitlements --force \
   .ci/pkg/tart
 cp Resources/embedded.provisionprofile .ci/pkg/embedded.provisionprofile

--- a/.ci/create-pkg.sh
+++ b/.ci/create-pkg.sh
@@ -6,6 +6,9 @@ export VERSION="${CIRRUS_TAG:-0}"
 
 mkdir -p .ci/pkg/
 cp .build/arm64-apple-macosx/release/tart .ci/pkg/tart
+codesign --sign "Developer ID Application: Cirrus Labs, Inc. (9M2P8L4D89)" \
+  --entitlements Resources/tart-prod.entitlements --force \
+  .ci/pkg/tart
 cp Resources/embedded.provisionprofile .ci/pkg/embedded.provisionprofile
 pkgbuild --root .ci/pkg/ --identifier com.github.cirruslabs.tart --version $VERSION \
   --scripts .ci/pkg/scripts \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,6 +76,10 @@ task:
     - security find-identity -v
     - xcodebuild -version
     - swift -version
+  build_script:
+    - .ci/set-version.sh
+    - swift build -c release --product tart
+    - ./.ci/create-pkg.sh
   goreleaser_script: goreleaser release --skip-publish --snapshot --clean
   always:
     dist_artifacts:
@@ -114,6 +118,10 @@ task:
     - security find-identity -v
     - xcodebuild -version
     - swift -version
+  build_script:
+    - .ci/set-version.sh
+    - swift build -c release --product tart
+    - ./.ci/create-pkg.sh
   release_script: goreleaser
   upload_sentry_debug_files_script:
     - cd .build/arm64-apple-macosx/release/

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,10 +76,6 @@ task:
     - security find-identity -v
     - xcodebuild -version
     - swift -version
-  build_script:
-    - .ci/set-version.sh
-    - swift build -c release --product tart
-    - ./.ci/create-pkg.sh
   goreleaser_script: goreleaser release --skip-publish --snapshot --clean
   always:
     dist_artifacts:
@@ -118,10 +114,6 @@ task:
     - security find-identity -v
     - xcodebuild -version
     - swift -version
-  build_script:
-    - .ci/set-version.sh
-    - swift build -c release --product tart
-    - ./.ci/create-pkg.sh
   release_script: goreleaser
   upload_sentry_debug_files_script:
     - cd .build/arm64-apple-macosx/release/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,5 @@
 project_name: tart
 
-before:
-  hooks:
-    - .ci/set-version.sh
-    - swift build -c release --product tart
-
 builds:
   - builder: prebuilt
     goos:
@@ -29,6 +24,8 @@ archives:
 
 release:
   prerelease: auto
+  extra_files:
+    - glob: ./.ci/Tart-{{ .Tag }}.pkg
 
 brews:
   - name: tart

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,11 @@
 project_name: tart
 
+before:
+  hooks:
+    - .ci/set-version.sh
+    - swift build -c release --product tart
+    - ./.ci/create-pkg.sh
+
 builds:
   - builder: prebuilt
     goos:


### PR DESCRIPTION
Last time it broke in https://github.com/cirruslabs/tart/issues/441. The theory is that notarization of the `.pkg` before after notarizaation of the binary was breaking validation on Apple side.

This attempt does build the .pkg before we do all the dance with gon ang goreleaser.