### PR TITLE
tart push: allow pushing OCI VMs from the cache too

### DIFF
--- a/Sources/tart/Commands/Push.swift
+++ b/Sources/tart/Commands/Push.swift
@@ -59,7 +59,9 @@ struct Push: AsyncParsableCommand {
 
       // If we're pushing a local OCI VM, check if points to an already existing registry manifest
       // and if so, only upload manifests (without config, disk and NVRAM) to the user-specified references
-      if let remoteName = try await lightweightPushToRegistry(registry: registry, references: references) {
+      if let remoteName = try? RemoteName(localName),
+         let remoteName = try await lightweightPushToRegistry(registry: registry, remoteName: remoteName,
+                                                              references: references) {
         pushedRemoteName = remoteName
         lightweightPush = true
       } else {
@@ -87,12 +89,7 @@ struct Push: AsyncParsableCommand {
     }
   }
 
-  func lightweightPushToRegistry(registry: Registry, references: [String]) async throws -> RemoteName? {
-    // Is the local name we're pushing is actually an OCI VM?
-    guard let remoteName = try? RemoteName(localName) else {
-      return nil
-    }
-
+  func lightweightPushToRegistry(registry: Registry, remoteName: RemoteName, references: [String]) async throws -> RemoteName? {
     // Is the local OCI VM already present in the registry?
     let digest = try VMStorageOCI().digest(remoteName)
 

--- a/Sources/tart/Commands/Push.swift
+++ b/Sources/tart/Commands/Push.swift
@@ -6,7 +6,7 @@ import Compression
 struct Push: AsyncParsableCommand {
   static var configuration = CommandConfiguration(abstract: "Push a VM to a registry")
 
-  @Argument(help: "local VM name")
+  @Argument(help: "local or remote VM name")
   var localName: String
 
   @Argument(help: "remote VM name(s)")
@@ -28,6 +28,7 @@ struct Push: AsyncParsableCommand {
   var populateCache: Bool = false
 
   func run() async throws {
+    let ociStorage = VMStorageOCI()
     let localVMDir = try VMStorageHelper.open(localName)
 
     // Parse remote names supplied by the user
@@ -54,34 +55,31 @@ struct Push: AsyncParsableCommand {
         + "\(registryIdentifier.host)/\(registryIdentifier.namespace)\(remoteNamesForRegistry.referenceNames())...")
 
       let references = remoteNamesForRegistry.map{ $0.reference.value }
-      let pushedRemoteName: RemoteName
-      let lightweightPush: Bool
 
+      let pushedRemoteName: RemoteName
       // If we're pushing a local OCI VM, check if points to an already existing registry manifest
       // and if so, only upload manifests (without config, disk and NVRAM) to the user-specified references
-      if let remoteName = try? RemoteName(localName),
-         let remoteName = try await lightweightPushToRegistry(registry: registry, remoteName: remoteName,
-                                                              references: references) {
-        pushedRemoteName = remoteName
-        lightweightPush = true
+      if let remoteName = try? RemoteName(localName) {
+        pushedRemoteName = try await lightweightPushToRegistry(
+          registry: registry, 
+          remoteName: remoteName,
+          references: references
+        )
       } else {
         pushedRemoteName = try await localVMDir.pushToRegistry(
           registry: registry,
           references: references,
           chunkSizeMb: chunkSize
         )
-        lightweightPush = false
-      }
-
-      // Populate the local cache (if requested)
-      if populateCache {
-        let ociStorage = VMStorageOCI()
-
-        if !lightweightPush {
+        // Populate the local cache (if requested)
+        if populateCache {
           let expectedPushedVMDir = try ociStorage.create(pushedRemoteName)
           try localVMDir.clone(to: expectedPushedVMDir, generateMAC: false)
         }
+      }
 
+      // link the rest remote names
+      if populateCache {
         for remoteName in remoteNamesForRegistry {
           try ociStorage.link(from: remoteName, to: pushedRemoteName)
         }
@@ -89,13 +87,11 @@ struct Push: AsyncParsableCommand {
     }
   }
 
-  func lightweightPushToRegistry(registry: Registry, remoteName: RemoteName, references: [String]) async throws -> RemoteName? {
+  func lightweightPushToRegistry(registry: Registry, remoteName: RemoteName, references: [String]) async throws -> RemoteName {
     // Is the local OCI VM already present in the registry?
     let digest = try VMStorageOCI().digest(remoteName)
 
-    guard let (remoteManifest, _) = try? await registry.pullManifest(reference: digest) else {
-      return nil
-    }
+    let (remoteManifest, _) = try await registry.pullManifest(reference: digest)
 
     // Overwrite registry's references with the retrieved manifest
     for reference in references {

--- a/Sources/tart/VMDirectory.swift
+++ b/Sources/tart/VMDirectory.swift
@@ -55,9 +55,9 @@ struct VMDirectory: Prunable {
     try? FileManager.default.removeItem(at: nvramURL)
   }
 
-  func validate() throws {
+  func validate(userFriendlyName: String) throws {
     if !FileManager.default.fileExists(atPath: baseURL.path) {
-      throw RuntimeError.VMDoesNotExist(name: baseURL.lastPathComponent)
+      throw RuntimeError.VMDoesNotExist(name: userFriendlyName)
     }
 
     if !initialized {

--- a/Sources/tart/VMStorageHelper.swift
+++ b/Sources/tart/VMStorageHelper.swift
@@ -57,6 +57,7 @@ enum RuntimeError : Error {
   case ExportFailed(_ message: String)
   case ImportFailed(_ message: String)
   case SoftnetFailed(_ message: String)
+  case OCIStorageError(_ message: String)
 }
 
 protocol HasExitCode {
@@ -98,6 +99,8 @@ extension RuntimeError : CustomStringConvertible {
       return "VM import failed: \(message)"
     case .SoftnetFailed(let message):
       return "Softnet failed: \(message)"
+    case .OCIStorageError(let message):
+      return "OCI storage error: \(message)"
     }
   }
 }

--- a/Sources/tart/VMStorageLocal.swift
+++ b/Sources/tart/VMStorageLocal.swift
@@ -14,7 +14,7 @@ class VMStorageLocal {
   func open(_ name: String) throws -> VMDirectory {
     let vmDir = VMDirectory(baseURL: vmURL(name))
 
-    try vmDir.validate()
+    try vmDir.validate(userFriendlyName: name)
 
     return vmDir
   }

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -16,10 +16,20 @@ class VMStorageOCI: PrunableStorage {
     VMDirectory(baseURL: vmURL(name)).initialized
   }
 
+  func digest(_ name: RemoteName) throws -> String {
+    let digest = vmURL(name).resolvingSymlinksInPath().lastPathComponent
+
+    if !digest.starts(with: "sha256:") {
+      throw RuntimeError.OCIStorageError("\(name) is not a digest and doesn't point to a digest")
+    }
+
+    return digest
+  }
+
   func open(_ name: RemoteName) throws -> VMDirectory {
     let vmDir = VMDirectory(baseURL: vmURL(name))
 
-    try vmDir.validate()
+    try vmDir.validate(userFriendlyName: name.description)
 
     try vmDir.baseURL.updateAccessDate()
 


### PR DESCRIPTION
Resolves https://github.com/cirruslabs/tart/issues/423.

Supersedes https://github.com/cirruslabs/tart/pull/461.