### PR TITLE
tart login: trim newline characters at the end of --password-stdin

### DIFF
--- a/Sources/tart/Commands/Login.swift
+++ b/Sources/tart/Commands/Login.swift
@@ -35,6 +35,9 @@ struct Login: AsyncParsableCommand {
 
       let passwordData = FileHandle.standardInput.readDataToEndOfFile()
       password = String(decoding: passwordData, as: UTF8.self)
+
+      // Support "echo $PASSWORD | tart login --username $USERNAME --password-stdin $REGISTRY"
+      password.trimSuffix { c in c.isNewline }
     } else {
       (user, password) = try StdinCredentials.retrieve()
     }


### PR DESCRIPTION
To support `echo $PASSWORD | tart login --username $USERNAME --password-stdin $REGISTRY` and avoid the need for `echo -n` which seems to be a gotcha for users: https://github.com/cirruslabs/tart/issues/483#issuecomment-1534348869.

This is similar to what `docker login` does: https://github.com/docker/cli/blob/054343be3855fea3375f185392128f6c54d9a39d/cli/command/registry/login.go#L97-L98.