### PR TITLE
Print errors to stderr

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -209,7 +209,7 @@ struct Run: AsyncParsableCommand {
         SentrySDK.capture(error: error)
         SentrySDK.flush(timeout: 2.seconds.timeInterval)
 
-        print(error)
+        fputs("\(error)\n", stderr)
 
         Foundation.exit(1)
       }

--- a/Sources/tart/Root.swift
+++ b/Sources/tart/Root.swift
@@ -94,7 +94,7 @@ struct Root: AsyncParsableCommand {
 
       // Handle a non-ArgumentParser's exception that requires a specific exit code to be set
       if let errorWithExitCode = error as? HasExitCode {
-        print(error)
+        fputs("\(error)\n", stderr)
 
         Foundation.exit(errorWithExitCode.exitCode)
       }


### PR DESCRIPTION
So that automation tools will have an easier time picking up the errors.