### PR TITLE
Use MainActor to ensure we're running on main queue

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -427,7 +427,7 @@ struct Run: AsyncParsableCommand {
               Task { try await vm!.virtualMachine.stop() }
             }
             Button("Request Stop") {
-              Task { try await vm!.virtualMachine.requestStop() }
+              Task { try vm!.virtualMachine.requestStop() }
             }
           }
         }

--- a/Sources/tart/VM+Recovery.swift
+++ b/Sources/tart/VM+Recovery.swift
@@ -5,34 +5,26 @@ import Dynamic
 // Kudos to @saagarjha's VirtualApple for finding about _VZVirtualMachineStartOptions
 
 extension VZVirtualMachine {
-  @available(macOS 12, *)
+  @MainActor @available(macOS 12, *)
   func start(_ recovery: Bool) async throws {
     if !recovery {
       // just use the regular API
-      return try await withCheckedThrowingContinuation { continuation in
-        DispatchQueue.main.async {
-          self.start(completionHandler: { result in
-            continuation.resume(with: result)
-          })
-        }
-      }
+      return try await self.start()
     }
 
     // use some private stuff only for recovery
     return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-      DispatchQueue.main.async {
-        let handler: @convention(block) (_ result: Any?) -> Void = { result in
-          if let error = result as? Error {
-            continuation.resume(throwing: error)
-          } else {
-            continuation.resume(returning: ())
-          }
+      let handler: @convention(block) (_ result: Any?) -> Void = { result in
+        if let error = result as? Error {
+          continuation.resume(throwing: error)
+        } else {
+          continuation.resume(returning: ())
         }
-        // dynamic magic
-        let options = Dynamic._VZVirtualMachineStartOptions()
-        options.bootMacOSRecovery = recovery
-        Dynamic(self)._start(withOptions: options, completionHandler: handler)
       }
+      // dynamic magic
+      let options = Dynamic._VZVirtualMachineStartOptions()
+      options.bootMacOSRecovery = recovery
+      Dynamic(self)._start(withOptions: options, completionHandler: handler)
     }
   }
 }


### PR DESCRIPTION
On macOS 14.0 (Sonoma), `Virtualization.Framework` allegedly improved it's GCD checks and added a `dispatch_assert_queue()` call to `VZVirtualMachine.start()` and `VZVirtualMachine.stop()` methods, which caused the Tart to crash on `tart run` and unveiled the fact that we weren't actually calling these methods from the main queue:

```
-------------------------------------
Translated Report (Full Report Below)
-------------------------------------

Process:               tart [20388]
Path:                  /Users/USER/*/tart
Identifier:            tart
Version:               ???
Code Type:             ARM-64 (Native)
Parent Process:        Exited process [20317]
Responsible:           Terminal [12421]
User ID:               501

Date/Time:             2023-06-07 14:36:05.2886 +0400
OS Version:            macOS 14.0 (23A5257q)
Report Version:        12
Anonymous UUID:        B52268FD-131F-36F7-6A95-F16DE1280232

Sleep/Wake UUID:       2FB56CBB-9A04-49F6-ADED-B34D10799EB5

Time Awake Since Boot: 15000 seconds
Time Since Wake:       7479 seconds

System Integrity Protection: enabled

Crashed Thread:        1

Exception Type:        EXC_BREAKPOINT (SIGTRAP)
Exception Codes:       0x0000000000000001, 0x000000019426fd84

Termination Reason:    Namespace SIGNAL, Code 5 Trace/BPT trap: 5
Terminating Process:   exc handler [20388]

Thread 0:
[skipped]

Thread 1 Crashed:
0   libdispatch.dylib             	       0x19426fd84 _dispatch_assert_queue_fail + 120
1   libdispatch.dylib             	       0x19426fd0c dispatch_assert_queue + 196
2   Virtualization                	       0x202aee618 -[VZVirtualMachine _startInternal:saveFileURL:completionHandler:] + 120
3   Virtualization                	       0x202af9f34 -[VZVirtualMachine startWithOptions:completionHandler:] + 80
4   tart                          	       0x1054d3e20 VM.run(_:) + 572 (VM.swift:230)
5   tart                          	       0x105428959 closure #2 in Run.run() + 1 (Run.swift:200)
6   tart                          	       0x105429e69 partial apply for closure #2 in Run.run() + 1
7   tart                          	       0x105030ce5 thunk for @escaping @callee_guaranteed @Sendable @async () -> (@out A) + 1
8   tart                          	       0x10503150d partial apply for thunk for @escaping @callee_guaranteed @Sendable @async () -> (@out A) + 1
9   libswift_Concurrency.dylib    	       0x22fb20d21 completeTaskWithClosure(swift::AsyncContext*, swift::SwiftError*) + 1
```

This can be easily verified by adding a call to `print(OperationQueue.current)` before `start()` or `stop()`.

Using `MainActor` also simplifies the code, as we don't need to use the old `completionHandler` function variants, except for the `Dynamic` case.