### PR TITLE
Fix "file “config.json” couldn’t be opened" error when pruning

### DIFF
--- a/Sources/tart/Commands/Prune.swift
+++ b/Sources/tart/Commands/Prune.swift
@@ -98,10 +98,11 @@ struct Prune: AsyncParsableCommand {
         break
       }
 
-      cacheReclaimedBytes += try prunable.sizeBytes()
-      try prunable.delete()
-
       try SentrySDK.span?.setExtra(value: prunable.sizeBytes(), key: prunable.url.path);
+
+      cacheReclaimedBytes += try prunable.sizeBytes()
+
+      try prunable.delete()
     }
 
     SentrySDK.span?.setMeasurement(name: "gc_disk_reclaimed", value: cacheReclaimedBytes as NSNumber, unit: MeasurementUnitInformation.byte);

--- a/Sources/tart/Commands/Prune.swift
+++ b/Sources/tart/Commands/Prune.swift
@@ -98,7 +98,7 @@ struct Prune: AsyncParsableCommand {
         break
       }
 
-      try SentrySDK.span?.setExtra(value: prunable.sizeBytes(), key: prunable.url.path);
+      try SentrySDK.span?.setExtra(value: prunable.sizeBytes(), key: prunable.url.path)
 
       cacheReclaimedBytes += try prunable.sizeBytes()
 


### PR DESCRIPTION
Problem: we were accessing prunable's `sizeBytes()` method after deleting it.

Solution: only access `sizeBytes()` before deleting the prunable.