### PR TITLE
Suspend/resume support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,6 +6,7 @@ env:
 task:
   name: Test on Ventura
   alias: test
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   persistent_worker:
     labels:
       name: dev-mini
@@ -30,6 +31,7 @@ task:
 task:
   name: Lint
   alias: lint
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode:$XCODE_TAG
   lint_script:
@@ -40,9 +42,10 @@ task:
       format: swiftformat
 
 task:
+  only_if: $CIRRUS_TAG == ''
   name: Build
   alias: build
-  only_if: $CIRRUS_TAG == ''
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode:$XCODE_TAG
   build_script: swift build --product tart
@@ -51,11 +54,12 @@ task:
     path: .build/debug/tart
 
 task:
-  name: Release (Dry Run)
   only_if: $CIRRUS_TAG == '' && ($CIRRUS_USER_PERMISSION == 'write' || $CIRRUS_USER_PERMISSION == 'admin')
+  name: Release (Dry Run)
   depends_on:
     - lint
     - build
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode:$XCODE_TAG
   env:
@@ -91,6 +95,7 @@ task:
     - lint
     - test
     - build
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode:$XCODE_TAG
   env:
@@ -135,6 +140,7 @@ task:
 task:
   name: Deploy Documentation
   only_if: $CIRRUS_BRANCH == 'main'
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   container:
     image: ghcr.io/cirruslabs/mkdocs-material-insiders:latest
     registry_config: ENCRYPTED[!cf1a0f25325aa75bad3ce6ebc890bc53eb0044c02efa70d8cefb83ba9766275a994b4831706c52630a0692b2fa9cfb9e!]

--- a/Sources/tart/Commands/Clone.swift
+++ b/Sources/tart/Commands/Clone.swift
@@ -44,8 +44,10 @@ struct Clone: AsyncParsableCommand {
       let lock = try FileLock(lockURL: Config().tartHomeDir)
       try lock.lock()
 
-      let generateMAC = try localStorage.hasVMsWithMACAddress(macAddress: sourceVM.macAddress())
+      let generateMAC = try localStorage.hasVMsWithMACAddress(macAddress: sourceVM.macAddress()) 
+        && sourceVM.state() != "suspended"
       try sourceVM.clone(to: tmpVMDir, generateMAC: generateMAC)
+
       try localStorage.move(newName, from: tmpVMDir)
 
       try lock.unlock()

--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -7,6 +7,7 @@ fileprivate struct VMInfo: Encodable {
   let Disk: Int
   let Display: String
   let Running: Bool
+  let State: String
 }
 
 struct Get: AsyncParsableCommand {
@@ -25,7 +26,7 @@ struct Get: AsyncParsableCommand {
     let memorySizeInMb = vmConfig.memorySize / 1024 / 1024
 
     let info = VMInfo(CPU: vmConfig.cpuCount, Memory: memorySizeInMb, Disk: diskSizeInGb,
-                      Display: vmConfig.display.description, Running: try vmDir.running())
+                      Display: vmConfig.display.description, Running: try vmDir.running(), State: try vmDir.state())
     print(format.renderSingle(info))
   }
 }

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -7,6 +7,7 @@ fileprivate struct VMInfo: Encodable {
   let Name: String
   let Size: Int
   let Running: Bool
+  let State: String
 }
 
 struct List: AsyncParsableCommand {
@@ -36,13 +37,13 @@ struct List: AsyncParsableCommand {
 
     if source == nil || source == "local" {
       infos += sortedInfos(try VMStorageLocal().list().map { (name, vmDir) in
-        try VMInfo(Source: "local", Name: name, Size: vmDir.sizeGB(), Running: vmDir.running())
+        try VMInfo(Source: "local", Name: name, Size: vmDir.sizeGB(), Running: vmDir.running(), State: vmDir.state())
       })
     }
 
     if source == nil || source == "oci" {
       infos += sortedInfos(try VMStorageOCI().list().map { (name, vmDir, _) in
-        try VMInfo(Source: "oci", Name: name, Size: vmDir.sizeGB(), Running: vmDir.running())
+        try VMInfo(Source: "oci", Name: name, Size: vmDir.sizeGB(), Running: vmDir.running(), State: vmDir.state())
       })
     }
 

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -94,7 +94,7 @@ struct Run: AsyncParsableCommand {
   var netSoftnet: Bool = false
 
   @Flag(help: ArgumentHelp("Disables audio and entropy devices and switches to only Mac-specific input devices.", discussion: "Useful for running a VM that can be suspended via \"tart suspend\"."))
-  var suspendable: Bool = false
+  static var suspendable: Bool = false
 
   mutating func validate() throws {
     if vnc && vncExperimental {
@@ -158,7 +158,7 @@ struct Run: AsyncParsableCommand {
       additionalDiskAttachments: additionalDiskAttachments,
       directorySharingDevices: directoryShares() + rosettaDirectoryShare(),
       serialPorts: serialPorts,
-      suspendable: suspendable
+      suspendable: Self.suspendable
     )
 
     let vncImpl: VNC? = try {
@@ -450,7 +450,7 @@ struct Run: AsyncParsableCommand {
             VMView(vm: vm!).onAppear {
               NSWindow.allowsAutomaticWindowTabbing = false
             }.onDisappear {
-              let ret = kill(getpid(), SIGINT)
+              let ret = kill(getpid(), Run.suspendable ? SIGUSR1 : SIGINT)
               if ret != 0 {
                 // Fallback to the old termination method that doesn't
                 // propagate the cancellation to Task's in case graceful

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -93,13 +93,7 @@ struct Run: AsyncParsableCommand {
                            discussion: "Learn how to configure Softnet for use with Tart here: https://github.com/cirruslabs/softnet"))
   var netSoftnet: Bool = false
 
-  @Flag(help: ArgumentHelp("Disable audio devices.", discussion: "Useful for running a VM that can be suspended via \"tart suspend\"."))
-  var noAudio: Bool = false
-
-  @Flag(help: ArgumentHelp("Disable entropy devices.", discussion: "Useful for running a VM that can be suspended via \"tart suspend\"."))
-  var noEntropy: Bool = false
-
-  @Flag(help: ArgumentHelp("An alias for --no-audio and --no-entropy."))
+  @Flag(help: ArgumentHelp("Disables audio and entropy devices and switches to only Mac-specific input devices.", discussion: "Useful for running a VM that can be suspended via \"tart suspend\"."))
   var suspendable: Bool = false
 
   mutating func validate() throws {
@@ -113,11 +107,6 @@ struct Run: AsyncParsableCommand {
 
     if graphics && noGraphics {
       throw ValidationError("--graphics and --no-graphics are mutually exclusive")
-    }
-
-    if suspendable {
-      self.noAudio = true
-      self.noEntropy = true
     }
   }
 
@@ -169,8 +158,7 @@ struct Run: AsyncParsableCommand {
       additionalDiskAttachments: additionalDiskAttachments,
       directorySharingDevices: directoryShares() + rosettaDirectoryShare(),
       serialPorts: serialPorts,
-      noAudio: noAudio,
-      noEntropy: noEntropy
+      suspendable: suspendable
     )
 
     let vncImpl: VNC? = try {

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -270,7 +270,7 @@ struct Run: AsyncParsableCommand {
 
             task.cancel()
           } else {
-            print("failed to create snapshot: this functionality is only supported on macOS 14 (Sonoma) or newer")
+            print(RuntimeError.SuspendFailed("this functionality is only supported on macOS 14 (Sonoma) or newer"))
 
             Foundation.exit(1)
           }

--- a/Sources/tart/Commands/Suspend.swift
+++ b/Sources/tart/Commands/Suspend.swift
@@ -1,0 +1,28 @@
+import ArgumentParser
+import Foundation
+import System
+import SwiftDate
+
+struct Suspend: AsyncParsableCommand {
+  static var configuration = CommandConfiguration(commandName: "suspend", abstract: "Suspend a VM")
+
+  @Argument(help: "VM name")
+  var name: String
+
+  func run() async throws {
+    let vmDir = try VMStorageLocal().open(name)
+    let lock = try PIDLock(lockURL: vmDir.configURL)
+
+    // Find the VM's PID
+    var pid = try lock.pid()
+    if pid == 0 {
+      throw RuntimeError.VMNotRunning("VM \"\(name)\" is not running")
+    }
+
+    // Tell the "tart run" process to suspend the VM
+    let ret = kill(pid, SIGUSR1)
+    if ret != 0 {
+      throw RuntimeError.SuspendFailed("failed to send SIGUSR1 signal to the \"tart run\" process running VM \"\(name)\"")
+    }
+  }
+}

--- a/Sources/tart/Formatter/Format.swift
+++ b/Sources/tart/Formatter/Format.swift
@@ -27,7 +27,11 @@ enum Format: String, ExpressibleByArgument, CaseIterable {
       let table = TextTable<T> { (item: T) in
         let mirroredObject = Mirror(reflecting: item)
         return mirroredObject.children.enumerated()
-          .filter {(_, element) in element.label! != "Running"}
+          .filter {(_, element) in
+            // Deprecate the "Running" field: only make it available
+            // from JSON for backwards-compatibility
+            element.label! != "Running"
+          }
           .map { (_, element) in
             let fieldName = element.label!
             return Column(title: fieldName, value: element.value)

--- a/Sources/tart/Formatter/Format.swift
+++ b/Sources/tart/Formatter/Format.swift
@@ -26,10 +26,12 @@ enum Format: String, ExpressibleByArgument, CaseIterable {
       }
       let table = TextTable<T> { (item: T) in
         let mirroredObject = Mirror(reflecting: item)
-        return mirroredObject.children.enumerated().map { (_, element) in
-          let fieldName = element.label!
-          return Column(title: fieldName, value: element.value)
-        }
+        return mirroredObject.children.enumerated()
+          .filter {(_, element) in element.label! != "Running"}
+          .map { (_, element) in
+            let fieldName = element.label!
+            return Column(title: fieldName, value: element.value)
+          }
       }
       return table.string(for: data, style: Style.plain)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     case .json:

--- a/Sources/tart/Platform/Darwin.swift
+++ b/Sources/tart/Platform/Darwin.swift
@@ -6,7 +6,7 @@ struct UnsupportedHostOSError: Error, CustomStringConvertible {
   }
 }
 
-struct Darwin: Platform {
+struct Darwin: PlatformSuspendable {
   var ecid: VZMacMachineIdentifier
   var hardwareModel: VZMacHardwareModel
 
@@ -107,7 +107,7 @@ struct Darwin: Platform {
     }
   }
 
-  func keyboardsSuspendable(suspendable: Bool = false) -> [VZKeyboardConfiguration] {
+  func keyboardsSuspendable() -> [VZKeyboardConfiguration] {
     if #available(macOS 14, *) {
       return [VZMacKeyboardConfiguration()]
     } else {

--- a/Sources/tart/Platform/Darwin.swift
+++ b/Sources/tart/Platform/Darwin.swift
@@ -107,12 +107,28 @@ struct Darwin: Platform {
     }
   }
 
+  func keyboardsSuspendable(suspendable: Bool = false) -> [VZKeyboardConfiguration] {
+    if #available(macOS 14, *) {
+      return [VZMacKeyboardConfiguration()]
+    } else {
+      return []
+    }
+  }
+
   func pointingDevices() -> [VZPointingDeviceConfiguration] {
     if #available(macOS 13, *) {
       // Trackpad is only supported by guests starting with macOS Ventura
       return [VZMacTrackpadConfiguration(), VZUSBScreenCoordinatePointingDeviceConfiguration()]
     } else {
       return [VZUSBScreenCoordinatePointingDeviceConfiguration()]
+    }
+  }
+
+  func pointingDevicesSuspendable() -> [VZPointingDeviceConfiguration] {
+    if #available(macOS 13, *) {
+      return [VZMacTrackpadConfiguration()]
+    } else {
+      return []
     }
   }
 }

--- a/Sources/tart/Platform/Platform.swift
+++ b/Sources/tart/Platform/Platform.swift
@@ -8,3 +8,8 @@ protocol Platform: Codable {
   func keyboards() -> [VZKeyboardConfiguration]
   func pointingDevices() -> [VZPointingDeviceConfiguration]
 }
+
+protocol PlatformSuspendable: Platform {
+  func pointingDevicesSuspendable() -> [VZPointingDeviceConfiguration]
+  func keyboardsSuspendable() -> [VZKeyboardConfiguration]
+}

--- a/Sources/tart/Root.swift
+++ b/Sources/tart/Root.swift
@@ -57,6 +57,11 @@ struct Root: AsyncParsableCommand {
       }
     }
 
+    // Add commands that are only available on specific macOS versions
+    if #available(macOS 14, *) {
+      configuration.subcommands.append(Suspend.self)
+    }
+
     // Ensure the default SIGINT handled is disabled,
     // otherwise there's a race between two handlers
     signal(SIGINT, SIG_IGN);

--- a/Sources/tart/VMDirectory.swift
+++ b/Sources/tart/VMDirectory.swift
@@ -92,6 +92,7 @@ struct VMDirectory: Prunable {
     try FileManager.default.copyItem(at: configURL, to: to.configURL)
     try FileManager.default.copyItem(at: nvramURL, to: to.nvramURL)
     try FileManager.default.copyItem(at: diskURL, to: to.diskURL)
+    try? FileManager.default.copyItem(at: stateURL, to: to.stateURL)
 
     // Re-generate MAC address
     if generateMAC {
@@ -107,6 +108,8 @@ struct VMDirectory: Prunable {
     var vmConfig = try VMConfig(fromURL: configURL)
 
     vmConfig.macAddress = VZMACAddress.randomLocallyAdministered()
+    // cleanup state if any
+    try? FileManager.default.removeItem(at: stateURL)
 
     try vmConfig.save(toURL: configURL)
   }

--- a/Sources/tart/VMDirectory.swift
+++ b/Sources/tart/VMDirectory.swift
@@ -13,6 +13,9 @@ struct VMDirectory: Prunable {
   var nvramURL: URL {
     baseURL.appendingPathComponent("nvram.bin")
   }
+  var stateURL: URL {
+    baseURL.appendingPathComponent("state.vzvmsave")
+  }
 
   var explicitlyPulledMark: URL {
     baseURL.appendingPathComponent(".explicitly-pulled")
@@ -37,6 +40,16 @@ struct VMDirectory: Prunable {
     }
 
     return try lock.pid() != 0
+  }
+
+  func state() throws -> String {
+    if try running() {
+      return "running"
+    } else if FileManager.default.fileExists(atPath: stateURL.path) {
+      return "suspended"
+    } else {
+      return "stopped"
+    }
   }
 
   static func temporary() throws -> VMDirectory {

--- a/Sources/tart/VMStorageHelper.swift
+++ b/Sources/tart/VMStorageHelper.swift
@@ -58,6 +58,7 @@ enum RuntimeError : Error {
   case ImportFailed(_ message: String)
   case SoftnetFailed(_ message: String)
   case OCIStorageError(_ message: String)
+  case SuspendFailed(_ message: String)
 }
 
 protocol HasExitCode {
@@ -101,6 +102,8 @@ extension RuntimeError : CustomStringConvertible {
       return "Softnet failed: \(message)"
     case .OCIStorageError(let message):
       return "OCI storage error: \(message)"
+    case .SuspendFailed(let message):
+      return "Failed to suspend the VM: \(message)"
     }
   }
 }


### PR DESCRIPTION
Unfortunately, changing the MAC-address after the snapshot is created is not possible (`Virtualization.Framework` throws an invalid argument exception when restoring), so we're not preserving the VM state when `tart clone`'ing.

Resolves https://github.com/cirruslabs/tart/issues/147.