### PR TITLE
Optimistically check if we need to do anything on a pull

### DIFF
--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -139,7 +139,7 @@ class VMStorageOCI: PrunableStorage {
 
     let digestName = RemoteName(host: name.host, namespace: name.namespace,
                                 reference: Reference(digest: Digest.hash(manifestData)))
-    
+
     if exists(name) && exists(digestName) && linked(from: name, to: digestName) {
       // optimistically check if we need to do anything at all before locking
       defaultLogger.appendNewLine("\(digestName) image is already cached and linked!")
@@ -236,7 +236,7 @@ class VMStorageOCI: PrunableStorage {
       return false
     }
   }
-  
+
   func link(from: RemoteName, to: RemoteName) throws {
     if FileManager.default.fileExists(atPath: vmURL(from).path) {
       try FileManager.default.removeItem(at: vmURL(from))


### PR DESCRIPTION
Right now on a pull we always acquire a lock for a registry host. This is problematic. For example, a worker can be pulling `ghcr.io/cirruslabs/macos-ventura-xcode:15-beta-2` image when a new request will come to pull `ghcr.io/cirruslabs/macos-ventura-xcode:latest` if needed.

In this situation, even though `ghcr.io/cirruslabs/macos-ventura-xcode:latest` is already cached and linked, `tart pull` will wait for a lock because the lock is per registry host.

This change optimistically check if there is something to do at all before acquiring a lock.