### PR TITLE
tart clone: try to reclaim disk space if needed

### DIFF
--- a/Sources/tart/Commands/Clone.swift
+++ b/Sources/tart/Commands/Clone.swift
@@ -31,6 +31,7 @@ struct Clone: AsyncParsableCommand {
     }
 
     let sourceVM = try VMStorageHelper.open(sourceName)
+    try Prune.reclaimIfNeeded(UInt64(sourceVM.sizeBytes()))
 
     let tmpVMDir = try VMDirectory.temporary()
 


### PR DESCRIPTION
To avoid cases when OCI images take large space amounts and prevent the new VMs from being cloned.