### PR TITLE
Fixed mouse/keyboard on Monterey guest

### DIFF
--- a/Sources/tart/Platform/Darwin.swift
+++ b/Sources/tart/Platform/Darwin.swift
@@ -100,7 +100,8 @@ struct Darwin: Platform {
 
   func keyboards() -> [VZKeyboardConfiguration] {
     if #available(macOS 14, *) {
-      return [VZMacKeyboardConfiguration()]
+      // Mac keyboard is only supported by guests starting with macOS Ventura
+      return [VZMacKeyboardConfiguration(), VZUSBKeyboardConfiguration()]
     } else {
       return [VZUSBKeyboardConfiguration()]
     }
@@ -108,7 +109,8 @@ struct Darwin: Platform {
 
   func pointingDevices() -> [VZPointingDeviceConfiguration] {
     if #available(macOS 13, *) {
-      return [VZMacTrackpadConfiguration()]
+      // Trackpad is only supported by guests starting with macOS Ventura
+      return [VZMacTrackpadConfiguration(), VZUSBScreenCoordinatePointingDeviceConfiguration()]
     } else {
       return [VZUSBScreenCoordinatePointingDeviceConfiguration()]
     }


### PR DESCRIPTION
I guess [my comment was accurate](https://github.com/cirruslabs/tart/pull/524/files#r1239939939). Fixes #534

Tested by running `ghcr.io/cirruslabs/macos-monterey-base:latest` locally on a Sonoma host.