### PR TITLE
Add `host` to `Registry` taking `port` into consideration

### DIFF
--- a/Sources/tart/Commands/Push.swift
+++ b/Sources/tart/Commands/Push.swift
@@ -100,7 +100,7 @@ struct Push: AsyncParsableCommand {
       _ = try await registry.pushManifest(reference: reference, manifest: remoteManifest)
     }
 
-    return RemoteName(host: registry.baseURL.host!, namespace: registry.namespace,
+    return RemoteName(host: registry.host!, namespace: registry.namespace,
                       reference: Reference(digest: digest))
   }
 }

--- a/Sources/tart/OCI/Registry.swift
+++ b/Sources/tart/OCI/Registry.swift
@@ -99,11 +99,21 @@ struct TokenResponse: Decodable, Authentication {
 }
 
 class Registry {
-  let baseURL: URL
+  private let baseURL: URL
   let namespace: String
   let credentialsProviders: [CredentialsProvider]
 
   var currentAuthToken: Authentication? = nil
+
+  var host: String? {
+    guard let host = baseURL.host else { return nil }
+
+    if let port = baseURL.port {
+      return "\(host):\(port)"
+    }
+
+    return host
+  }
 
   init(urlComponents: URLComponents,
        namespace: String,

--- a/Sources/tart/VMDirectory+OCI.swift
+++ b/Sources/tart/VMDirectory+OCI.swift
@@ -159,7 +159,7 @@ extension VMDirectory {
     }
 
     let pushedReference = Reference(digest: try manifest.digest())
-    return RemoteName(host: registry.baseURL.host!, namespace: registry.namespace, reference: pushedReference)
+    return RemoteName(host: registry.host!, namespace: registry.namespace, reference: pushedReference)
   }
 }
 


### PR DESCRIPTION
Replaces `baseURL.host!`, hopefully fixes https://github.com/cirruslabs/tart/issues/543