### PR TITLE
Introduce TART_REGISTRY_HOSTNAME

### DIFF
--- a/Sources/tart/Credentials/EnvironmentCredentialsProvider.swift
+++ b/Sources/tart/Credentials/EnvironmentCredentialsProvider.swift
@@ -2,6 +2,11 @@ import Foundation
 
 class EnvironmentCredentialsProvider: CredentialsProvider {
   func retrieve(host: String) throws -> (String, String)? {
+    if let tartRegistryHost = ProcessInfo.processInfo.environment["TART_REGISTRY_HOST"],
+       tartRegistryHost != host {
+      return nil
+    }
+
     let username = ProcessInfo.processInfo.environment["TART_REGISTRY_USERNAME"]
     let password = ProcessInfo.processInfo.environment["TART_REGISTRY_PASSWORD"]
     if let username = username, let password = password {

--- a/Sources/tart/Credentials/EnvironmentCredentialsProvider.swift
+++ b/Sources/tart/Credentials/EnvironmentCredentialsProvider.swift
@@ -2,8 +2,8 @@ import Foundation
 
 class EnvironmentCredentialsProvider: CredentialsProvider {
   func retrieve(host: String) throws -> (String, String)? {
-    if let tartRegistryHost = ProcessInfo.processInfo.environment["TART_REGISTRY_HOST"],
-       tartRegistryHost != host {
+    if let tartRegistryHostname = ProcessInfo.processInfo.environment["TART_REGISTRY_HOSTNAME"],
+       tartRegistryHostname != host {
       return nil
     }
 


### PR DESCRIPTION
When specified, Tart will additionally check if the host that the image is being pulled from matches that environment variable, and if not, the credential evaluation will continue.

This will allow to fix https://github.com/cirruslabs/gitlab-tart-executor/issues/28#issuecomment-1628971742.