### PR TITLE
Updated garbage collection

### DIFF
--- a/Sources/tart/Root.swift
+++ b/Sources/tart/Root.swift
@@ -81,10 +81,12 @@ struct Root: AsyncParsableCommand {
       var command = try parseAsRoot()
 
       // Run garbage-collection before each command (shouldn't take too long)
-      do {
-        try Config().gc()
-      } catch {
-        fputs("Failed to perform garbage collection!\n\(error)\n", stderr)
+      if type(of: command) != type(of: Pull()) && type(of: command) != type(of: Clone()){
+        do {
+          try Config().gc()
+        } catch {
+          fputs("Failed to perform garbage collection!\n\(error)\n", stderr)
+        }
       }
 
       if var asyncCommand = command as? AsyncParsableCommand {


### PR DESCRIPTION
- Add check to see if command is Pull or Clone

- Doesn't do garbage collection if command is Pull or Clone


This is for: [Step 2](https://github.com/cirruslabs/tart/issues/444#issuecomment-1622210092)