### PR TITLE
Fix `prune --older-than` deleting all cache

### DIFF
--- a/Sources/tart/Commands/Prune.swift
+++ b/Sources/tart/Commands/Prune.swift
@@ -34,7 +34,9 @@ struct Prune: AsyncParsableCommand {
     // Clean up cache entries based on last accessed date
     if let olderThan = olderThan {
       let olderThanInterval = Int(exactly: olderThan)!.days.timeInterval
-      let olderThanDate = Date().addingTimeInterval(olderThanInterval)
+      // olderThanInterval is positive (eg. 7 days) - we need to _subtract_
+      // the interval from current time to get "older than" date - hence * -1.
+      let olderThanDate = Date().addingTimeInterval(olderThanInterval * -1)
 
       try Prune.pruneOlderThan(olderThanDate: olderThanDate)
     }

--- a/Sources/tart/Commands/Prune.swift
+++ b/Sources/tart/Commands/Prune.swift
@@ -34,9 +34,7 @@ struct Prune: AsyncParsableCommand {
     // Clean up cache entries based on last accessed date
     if let olderThan = olderThan {
       let olderThanInterval = Int(exactly: olderThan)!.days.timeInterval
-      // olderThanInterval is positive (eg. 7 days) - we need to _subtract_
-      // the interval from current time to get "older than" date - hence * -1.
-      let olderThanDate = Date().addingTimeInterval(olderThanInterval * -1)
+      let olderThanDate = Date() - olderThanInterval
 
       try Prune.pruneOlderThan(olderThanDate: olderThanDate)
     }


### PR DESCRIPTION
I noticed when I ran `prune --older-than=7` `tart` deleted some images I didn't expect it to (because I used them lately). I looked into `Prune` and it seems the sign is wrong on the `olderThan` argument handling.

## Before

<img width="650" alt="Zrzut ekranu 2023-07-11 o 10 26 37" src="https://github.com/cirruslabs/tart/assets/1151041/024b43a6-9e1a-456e-bf3d-56b1b20306f4">

## After

<img width="740" alt="Zrzut ekranu 2023-07-11 o 10 33 58" src="https://github.com/cirruslabs/tart/assets/1151041/47139f0d-69b7-4eea-8e71-43d2afd2bbb4">
