### PR TITLE
Upload debug files to both Sentry projects

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -127,12 +127,12 @@ task:
     - cd .build/arm64-apple-macosx/release/
     # Generate and upload symbols
     - dsymutil tart
-    - sentry-cli debug-files upload -o cirrus-labs -p tart tart.dSYM/
-    - sentry-cli debug-files upload -o cirrus-labs -p persistent-workers tart.dSYM/
+    - sentry-cli debug-files upload tart.dSYM/
+    - SENTRY_PROJECT=tart sentry-cli debug-files upload tart.dSYM/
     # Bundle and upload sources
     - sentry-cli debug-files bundle-sources tart.dSYM
-    - sentry-cli debug-files upload -o cirrus-labs -p tart tart.src.zip
-    - sentry-cli debug-files upload -o cirrus-labs -p persistent-workers tart.src.zip
+    - sentry-cli debug-files upload tart.src.zip
+    - SENTRY_PROJECT=tart sentry-cli debug-files upload tart.src.zip
   create_sentry_release_script:
     - export SENTRY_RELEASE="tart@$CIRRUS_TAG"
     - sentry-cli releases new $SENTRY_RELEASE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -127,10 +127,12 @@ task:
     - cd .build/arm64-apple-macosx/release/
     # Generate and upload symbols
     - dsymutil tart
-    - sentry-cli debug-files upload tart.dSYM/
+    - sentry-cli debug-files upload -o cirrus-labs -p tart tart.dSYM/
+    - sentry-cli debug-files upload -o cirrus-labs -p persistent-workers tart.dSYM/
     # Bundle and upload sources
     - sentry-cli debug-files bundle-sources tart.dSYM
-    - sentry-cli debug-files upload tart.src.zip
+    - sentry-cli debug-files upload -o cirrus-labs -p tart tart.src.zip
+    - sentry-cli debug-files upload -o cirrus-labs -p persistent-workers tart.src.zip
   create_sentry_release_script:
     - export SENTRY_RELEASE="tart@$CIRRUS_TAG"
     - sentry-cli releases new $SENTRY_RELEASE


### PR DESCRIPTION
Apparently it's not possible to share debug files cross projects. So let's upload to both of them. To one we use in production and one we use for testing.