### PR TITLE
Retrieve VM's IP for use in VNC after the VM is started

### DIFF
--- a/Sources/tart/VNC/FullFledgedVNC.swift
+++ b/Sources/tart/VNC/FullFledgedVNC.swift
@@ -2,7 +2,7 @@ import Foundation
 import Dynamic
 import Virtualization
 
-class FullFledgedVNC: VNC {
+class FullFledgedVNC: VNCNotifier, VNC {
   let password: String
   private let vnc: Dynamic
 

--- a/Sources/tart/VNC/ScreenSharingVNC.swift
+++ b/Sources/tart/VNC/ScreenSharingVNC.swift
@@ -2,7 +2,7 @@ import Foundation
 import Dynamic
 import Virtualization
 
-class ScreenSharingVNC: VNC {
+class ScreenSharingVNC: VNCNotifier, VNC {
   let vmConfig: VMConfig
 
   init(vmConfig: VMConfig) {

--- a/Sources/tart/VNC/VNC.swift
+++ b/Sources/tart/VNC/VNC.swift
@@ -2,5 +2,23 @@ import Foundation
 
 protocol VNC {
   func waitForURL() async throws -> URL
+
+  func setUserNotifier(notifier: @escaping (URL) -> ())
+  func notifyUser(vncURL: URL)
+
   func stop() throws
+}
+
+class VNCNotifier {
+  var notifier: ((URL) -> ())?
+
+  func setUserNotifier(notifier: @escaping (URL) -> ()) {
+    self.notifier = notifier
+  }
+
+  func notifyUser(vncURL: URL) {
+    if let notifier = notifier {
+      notifier(vncURL)
+    }
+  }
 }


### PR DESCRIPTION
Currently `tart run --vnc <name>` doesn't work because the `ScreenSharingVNC` tries to retrieve the VM's IP first: https://github.com/cirruslabs/tart/blob/4ce06279ff2376837c65933870ddb4a356d5f50e/Sources/tart/VNC/ScreenSharingVNC.swift#L14

...but at this point the VM is not started yet, so `tart run` locks up waiting for a miracle (which does happen when a VM with such MAC-address was already started on the host and the DHCPD lease was created for it).