### PR TITLE
[skip ci] Downgrade Lottie Player

### DIFF
--- a/docs/theme/overrides/home.html
+++ b/docs/theme/overrides/home.html
@@ -81,7 +81,7 @@
   }
 </style>
 
-<script src="https://unpkg.com/@dotlottie/player-component@latest/dist/dotlottie-player.js"></script>
+<script src="https://unpkg.com/@dotlottie/player-component@1.4.0/dist/dotlottie-player.js"></script>
 
 <!-- landing page for landing page -->
 <!-- Hero -->


### PR DESCRIPTION
Seems in 2.0.0 release they broke looping. Right now animation on https://tart.run/ is always looping even without `loop` property. I was able to disable it, so I just downgraded to the last known working version.