### PR TITLE
GC avoidance and tmpDeterminstic

### DIFF
--- a/Sources/tart/Root.swift
+++ b/Sources/tart/Root.swift
@@ -81,10 +81,12 @@ struct Root: AsyncParsableCommand {
       var command = try parseAsRoot()
 
       // Run garbage-collection before each command (shouldn't take too long)
-      do {
-        try Config().gc()
-      } catch {
-        fputs("Failed to perform garbage collection!\n\(error)\n", stderr)
+      if type(of: command) != type(of: Pull()) && type(of: command) != type(of: Clone()){
+        do {
+          try Config().gc()
+        } catch {
+          fputs("Failed to perform garbage collection!\n\(error)\n", stderr)
+        }
       }
 
       if var asyncCommand = command as? AsyncParsableCommand {

--- a/Sources/tart/VMDirectory.swift
+++ b/Sources/tart/VMDirectory.swift
@@ -59,6 +59,19 @@ struct VMDirectory: Prunable {
     return VMDirectory(baseURL: tmpDir)
   }
 
+  static func temporaryDeterministic(fileName: String) throws -> VMDirectory {
+    let fileNameNoSlash = fileName.replacingOccurrences(of: "/", with: "-")
+    let tmpDir = try Config().tartTmpDir.appendingPathComponent(fileNameNoSlash)
+    do {
+      try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: false)
+    }
+    catch{
+      defaultLogger.appendNewLine("\(fileNameNoSlash) exists")
+    }
+
+    return VMDirectory(baseURL: tmpDir)
+  }
+
   var initialized: Bool {
     FileManager.default.fileExists(atPath: configURL.path) &&
       FileManager.default.fileExists(atPath: diskURL.path) &&

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -170,7 +170,7 @@ class VMStorageOCI: PrunableStorage {
 
     if !exists(digestName) {
       let transaction = SentrySDK.startTransaction(name: name.description, operation: "pull", bindToScope: true)
-      let tmpVMDir = try VMDirectory.temporary()
+      let tmpVMDir = try VMDirectory.temporaryDeterministic(fileName: name.namespace)
 
       // Lock the temporary VM directory to prevent it's garbage collection
       let tmpVMDirLock = try FileLock(lockURL: tmpVMDir.baseURL)


### PR DESCRIPTION
- avoid GC when command is a pull or clone
- make tmp VM names deterministic

From [this](https://github.com/cirruslabs/tart/pull/561#issuecomment-1653933742)