### PR TITLE
Support Docker's `credsStore`

### DIFF
--- a/Sources/tart/Credentials/DockerConfigCredentialsProvider.swift
+++ b/Sources/tart/Credentials/DockerConfigCredentialsProvider.swift
@@ -14,6 +14,10 @@ class DockerConfigCredentialsProvider: CredentialsProvider {
     if let helperProgram = config.credHelpers?[host] {
       return try executeHelper(binaryName: "docker-credential-\(helperProgram)", host: host)
     }
+    
+    if let defaultCredsStore = config.credsStore {
+      return try executeHelper(binaryName: "docker-credential-\(defaultCredsStore)", host: host)
+    }
 
     return nil
   }
@@ -59,6 +63,7 @@ class DockerConfigCredentialsProvider: CredentialsProvider {
 struct DockerConfig: Codable {
   var auths: Dictionary<String, DockerAuthConfig>? = Dictionary()
   var credHelpers: Dictionary<String, String>? = Dictionary()
+  var credsStore: String? = nil
 }
 
 struct DockerAuthConfig: Codable {

--- a/Sources/tart/Credentials/DockerConfigCredentialsProvider.swift
+++ b/Sources/tart/Credentials/DockerConfigCredentialsProvider.swift
@@ -14,7 +14,7 @@ class DockerConfigCredentialsProvider: CredentialsProvider {
     if let helperProgram = config.credHelpers?[host] {
       return try executeHelper(binaryName: "docker-credential-\(helperProgram)", host: host)
     }
-    
+
     if let defaultCredsStore = config.credsStore {
       return try executeHelper(binaryName: "docker-credential-\(defaultCredsStore)", host: host)
     }


### PR DESCRIPTION
This way for #581 we don't need to specify a fully quialified URL and can simply use the following `~/.docker/config.json`:

```json
{
	"credsStore": "ecr-login"
}
```

Related to https://github.com/docker/cli/issues/2928