### PR TITLE
Support wildcards in `credHelpers`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,7 @@ brews:
       libexec.install Dir["*"]
       bin.write_exec_script "#{libexec}/tart.app/Contents/MacOS/tart"
     custom_block: |
-      depends_on :macos => :monterey
+      depends_on :macos => :ventura
       
       on_macos do
         unless Hardware::CPU.arm?

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
   name: "Tart",
   platforms: [
-    .macOS(.v12)
+    .macOS(.v13)
   ],
   products: [
     .executable(name: "tart", targets: ["tart"])

--- a/Sources/tart/Commands/Create.swift
+++ b/Sources/tart/Commands/Create.swift
@@ -47,11 +47,7 @@ struct Create: AsyncParsableCommand {
       }
 
       if linux {
-        if #available(macOS 13, *) {
-          _ = try await VM.linux(vmDir: tmpVMDir, diskSizeGB: diskSize)
-        } else {
-          throw UnsupportedOSError("Linux VMs", "are")
-        }
+        _ = try await VM.linux(vmDir: tmpVMDir, diskSizeGB: diskSize)
       }
 
       try VMStorageLocal().move(name, from: tmpVMDir)

--- a/Sources/tart/Platform/Darwin.swift
+++ b/Sources/tart/Platform/Darwin.swift
@@ -116,19 +116,11 @@ struct Darwin: PlatformSuspendable {
   }
 
   func pointingDevices() -> [VZPointingDeviceConfiguration] {
-    if #available(macOS 13, *) {
-      // Trackpad is only supported by guests starting with macOS Ventura
-      return [VZMacTrackpadConfiguration(), VZUSBScreenCoordinatePointingDeviceConfiguration()]
-    } else {
-      return [VZUSBScreenCoordinatePointingDeviceConfiguration()]
-    }
+    // Trackpad is only supported by guests starting with macOS Ventura
+    [VZMacTrackpadConfiguration(), VZUSBScreenCoordinatePointingDeviceConfiguration()]
   }
 
   func pointingDevicesSuspendable() -> [VZPointingDeviceConfiguration] {
-    if #available(macOS 13, *) {
-      return [VZMacTrackpadConfiguration()]
-    } else {
-      return []
-    }
+    [VZMacTrackpadConfiguration()]
   }
 }

--- a/Sources/tart/VMConfig.swift
+++ b/Sources/tart/VMConfig.swift
@@ -97,11 +97,7 @@ struct VMConfig: Codable {
     case .darwin:
       platform = try Darwin(from: decoder)
     case .linux:
-      if #available(macOS 13, *) {
-        platform = try Linux(from: decoder)
-      } else {
-        throw UnsupportedOSError("Linux VMs", "are")
-      }
+      platform = try Linux(from: decoder)
     }
     cpuCountMin = try container.decode(Int.self, forKey: .cpuCountMin)
     cpuCount = try container.decode(Int.self, forKey: .cpuCount)

--- a/Tests/TartTests/DockerConfigTests.swift
+++ b/Tests/TartTests/DockerConfigTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import tart
+
+final class DockerConfigTests: XCTestCase {
+  func testHelpers() throws {
+    let config = DockerConfig(credHelpers: [
+      "(.*).dkr.ecr.(.*).amazonaws.com": "ecr-login",
+      "gcr.io": "gcloud"
+    ])
+
+    XCTAssertEqual(try config.findCredHelper(host: "gcr.io"), "gcloud")
+    XCTAssertEqual(try config.findCredHelper(host: "123.dkr.ecr.eu-west-1.amazonaws.com"), "ecr-login")
+    XCTAssertEqual(try config.findCredHelper(host: "456.dkr.ecr.us-east-1.amazonaws.com"), "ecr-login")
+    XCTAssertNil(try config.findCredHelper(host: "ghcr.io"))
+  }
+}


### PR DESCRIPTION
With #591 `tart pull` fails when for example you have `ecr-login` set as the default `credsStore` but you try to pull our images from `ghcr.io`.

This change reverts #591 and instead supports regex in `credHelpers`. This is not supported by Docker itself but highly demanded in https://github.com/docker/cli/issues/2928

I think it's fine to support it for Tart.

Additionally this change bumps the minimum host macOS version to Ventura in order to bring `Regex`. Yes, `Regex` only supported in Swift for macOS 13+ 🤦‍♂️I think it's fine in the light of Sonoma release and Tart 2.0.0.