### PR TITLE
Customizable disk syncing mode

### DIFF
--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -328,7 +328,11 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     }
 
     // Storage
-    var attachments = [try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false)]
+    var diskSyncMode: VZDiskImageSynchronizationMode = ProcessInfo.processInfo.environment["CI"] != nil ? .none : .full
+    if let userDefinedSyncMode = ProcessInfo.processInfo.environment["TART_DISK_SYNC_MODE"] {
+      diskSyncMode = VZDiskImageSynchronizationMode(rawValue: Int(userDefinedSyncMode) ?? 1) ?? diskSyncMode
+    }
+    var attachments = [try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false, cachingMode: .automatic, synchronizationMode: diskSyncMode)]
     attachments.append(contentsOf: additionalDiskAttachments)
     configuration.storageDevices = attachments.map { VZVirtioBlockDeviceConfiguration(attachment: $0) }
 

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -328,11 +328,17 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     }
 
     // Storage
-    var diskSyncMode: VZDiskImageSynchronizationMode = ProcessInfo.processInfo.environment["CI"] != nil ? .none : .full
+    var userDefinedDiskSyncMode: VZDiskImageSynchronizationMode? = ProcessInfo.processInfo.environment["CI"] != nil ? VZDiskImageSynchronizationMode.none : nil
     if let userDefinedSyncMode = ProcessInfo.processInfo.environment["TART_DISK_SYNC_MODE"] {
-      diskSyncMode = VZDiskImageSynchronizationMode(rawValue: Int(userDefinedSyncMode) ?? 1) ?? diskSyncMode
+      userDefinedDiskSyncMode = VZDiskImageSynchronizationMode(rawValue: Int(userDefinedSyncMode) ?? 1) ?? userDefinedDiskSyncMode
     }
-    var attachments = [try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false, cachingMode: .automatic, synchronizationMode: diskSyncMode)]
+    var attachments: [VZDiskImageStorageDeviceAttachment] = []
+    if (userDefinedDiskSyncMode != nil) {
+      attachments.append(try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false, cachingMode: .automatic, synchronizationMode: userDefinedDiskSyncMode!))
+    } else {
+      // with defaults
+      attachments.append(try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false))      
+    }
     attachments.append(contentsOf: additionalDiskAttachments)
     configuration.storageDevices = attachments.map { VZVirtioBlockDeviceConfiguration(attachment: $0) }
 


### PR DESCRIPTION
On my local MBP I didn't notice any significant I/O improvements. Around 5% but it might be just statistics.

[Allegedly it can improve IO on some disks](https://developer.apple.com/documentation/virtualization/vzdiskimagesynchronizationmode/none#discussion).

Opening it as a draft in case anyone will want to check it. I will check it this week on a AWS Mac Mini which has a 3x slower EBS network volume where this change might bring significant improvements.