### PR TITLE
Return exit code 2 on RuntimeError.VMDoesNotExist

### DIFF
--- a/Sources/tart/VMStorageHelper.swift
+++ b/Sources/tart/VMStorageHelper.swift
@@ -34,9 +34,15 @@ class VMStorageHelper {
   }
 }
 
+extension NSError {
+  func isFileNotFound() -> Bool {
+    return self.code == NSFileNoSuchFileError || self.code == NSFileReadNoSuchFileError
+  }
+}
+
 extension Error {
   func isFileNotFound() -> Bool {
-    (self as NSError).code == NSFileReadNoSuchFileError
+    (self as NSError).isFileNotFound() || (self as NSError).underlyingErrors.contains(where: { $0.isFileNotFound() })
   }
 }
 

--- a/Sources/tart/VMStorageHelper.swift
+++ b/Sources/tart/VMStorageHelper.swift
@@ -111,6 +111,8 @@ extension RuntimeError : CustomStringConvertible {
 extension RuntimeError : HasExitCode {
   var exitCode: Int32 {
     switch self {
+    case .VMDoesNotExist:
+      return 2
     case .VMNotRunning:
       return 2
     case .VMAlreadyRunning:


### PR DESCRIPTION
Also upgrade `isFileNotFound()` do detect underlying errors.

See https://github.com/cirruslabs/orchard/pull/125.