### PR TITLE
Support block devices on Sonoma

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Cocoa
+import Darwin
 import Dispatch
 import SwiftUI
 import Virtualization
@@ -53,6 +54,8 @@ struct Run: AsyncParsableCommand {
   @Option(help: ArgumentHelp("""
   Additional disk attachments with an optional read-only specifier\n(e.g. --disk=\"disk.bin\" --disk=\"ubuntu.iso:ro\")
   """, discussion: """
+  Can be either a disk image file or a block device like local SSD on AWS EC2 Mac instances.
+
   Learn how to create a disk image using Disk Utility here:
   https://support.apple.com/en-gb/guide/disk-utility/dskutl11888/mac
   """, valueName: "path[:ro]"))
@@ -146,20 +149,6 @@ struct Run: AsyncParsableCommand {
 
     let additionalDiskAttachments = try additionalDiskAttachments()
 
-    // Error out if the disk is locked by the host (e.g. it was mounted in Finder),
-    // see https://github.com/cirruslabs/tart/issues/323 for more details.
-    for additionalDiskAttachment in additionalDiskAttachments {
-      // Read-only attachments do not seem to acquire the lock
-      if additionalDiskAttachment.isReadOnly {
-        continue
-      }
-
-      if try !FileLock(lockURL: additionalDiskAttachment.url).trylock() {
-        throw RuntimeError.DiskAlreadyInUse("disk \(additionalDiskAttachment.url.path) seems to be already in use, "
-          + "unmount it first in Finder")
-      }
-    }
-
     var serialPorts: [VZSerialPortConfiguration] = []
     if serial {
       let tty_fd = createPTY()
@@ -181,7 +170,7 @@ struct Run: AsyncParsableCommand {
     vm = try VM(
       vmDir: vmDir,
       network: userSpecifiedNetwork(vmDir: vmDir) ?? NetworkShared(),
-      additionalDiskAttachments: additionalDiskAttachments,
+      additionalStorageDevices: additionalDiskAttachments,
       directorySharingDevices: directoryShares() + rosettaDirectoryShare(),
       serialPorts: serialPorts,
       suspendable: suspendable
@@ -361,22 +350,37 @@ struct Run: AsyncParsableCommand {
     }
   }
 
-  func additionalDiskAttachments() throws -> [VZDiskImageStorageDeviceAttachment] {
-    var result: [VZDiskImageStorageDeviceAttachment] = []
+  func additionalDiskAttachments() throws -> [VZStorageDeviceConfiguration] {
+    var result: [VZStorageDeviceConfiguration] = []
     let readOnlySuffix = ":ro"
     let expandedDiskPaths = disk.map { NSString(string:$0).expandingTildeInPath }
 
     for rawDisk in expandedDiskPaths {
-      if rawDisk.hasSuffix(readOnlySuffix) {
-        result.append(try VZDiskImageStorageDeviceAttachment(
-          url: URL(fileURLWithPath: String(rawDisk.prefix(rawDisk.count - readOnlySuffix.count))),
-          readOnly: true
-        ))
+      let diskReadOnly = rawDisk.hasSuffix(readOnlySuffix)
+      let diskPath = diskReadOnly ? String(rawDisk.prefix(rawDisk.count - readOnlySuffix.count)) : rawDisk
+      let diskURL = URL(fileURLWithPath: diskPath)
+
+      // check if `diskPath` is a block device or a directory
+      if pathHasMode(diskPath, mode: S_IFBLK) || pathHasMode(diskPath, mode: S_IFDIR) {
+        print("Using block device\n")
+        guard #available(macOS 14, *) else {
+          throw UnsupportedOSError("attaching block devices", "are")
+        }
+        let fileHandle = try FileHandle(forUpdating: diskURL)
+        let attachment = try VZDiskBlockDeviceStorageDeviceAttachment(fileHandle: fileHandle, readOnly: diskReadOnly, synchronizationMode: .full)
+        result.append(VZVirtioBlockDeviceConfiguration(attachment: attachment))
       } else {
-        result.append(try VZDiskImageStorageDeviceAttachment(
-          url: URL(fileURLWithPath: rawDisk),
-          readOnly: false
-        ))
+        // Error out if the disk is locked by the host (e.g. it was mounted in Finder),
+        // see https://github.com/cirruslabs/tart/issues/323 for more details.
+        if try !diskReadOnly && !FileLock(lockURL: diskURL).trylock() {
+          throw RuntimeError.DiskAlreadyInUse("disk \(diskURL.url.path) seems to be already in use, unmount it first in Finder")
+        }
+
+        let diskImageAttachment = try VZDiskImageStorageDeviceAttachment(
+          url: diskURL,
+          readOnly: diskReadOnly
+        )
+        result.append(VZVirtioBlockDeviceConfiguration(attachment: diskImageAttachment))
       }
     }
 
@@ -621,4 +625,13 @@ extension String {
   func toFilePathURL() -> URL {
     URL(fileURLWithPath: NSString(string: self).expandingTildeInPath)
   }
+}
+
+func pathHasMode(_ path: String, mode: mode_t) -> Bool {
+  var st = stat()
+  let statRes = stat(path, &st)
+  guard statRes != -1 else {
+    return false
+  }
+  return (Int32(st.st_mode) & Int32(mode)) == Int32(mode)
 }

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -11,6 +11,9 @@ struct NoMainScreenFoundError: Error {
 struct DownloadFailed: Error {
 }
 
+struct CanNotAccessBlockDevice: Error {
+}
+
 struct UnsupportedOSError: Error, CustomStringConvertible {
   let description: String
 
@@ -42,7 +45,7 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
 
   init(vmDir: VMDirectory,
        network: Network = NetworkShared(),
-       additionalDiskAttachments: [VZDiskImageStorageDeviceAttachment] = [],
+       additionalStorageDevices: [VZStorageDeviceConfiguration] = [],
        directorySharingDevices: [VZDirectorySharingDeviceConfiguration] = [],
        serialPorts: [VZSerialPortConfiguration] = [],
        suspendable: Bool = false
@@ -58,7 +61,7 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     self.network = network
     configuration = try Self.craftConfiguration(diskURL: vmDir.diskURL,
                                                 nvramURL: vmDir.nvramURL, vmConfig: config,
-                                                network: network, additionalDiskAttachments: additionalDiskAttachments,
+                                                network: network, additionalStorageDevices: additionalStorageDevices,
                                                 directorySharingDevices: directorySharingDevices,
                                                 serialPorts: serialPorts,
                                                 suspendable: suspendable
@@ -142,7 +145,7 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     ipswURL: URL,
     diskSizeGB: UInt16,
     network: Network = NetworkShared(),
-    additionalDiskAttachments: [VZDiskImageStorageDeviceAttachment] = [],
+    additionalStorageDevices: [VZStorageDeviceConfiguration] = [],
     directorySharingDevices: [VZDirectorySharingDeviceConfiguration] = [],
     serialPorts: [VZSerialPortConfiguration] = []
   ) async throws {
@@ -190,7 +193,7 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     self.network = network
     configuration = try Self.craftConfiguration(diskURL: vmDir.diskURL, nvramURL: vmDir.nvramURL,
                                                 vmConfig: config, network: network,
-                                                additionalDiskAttachments: additionalDiskAttachments,
+                                                additionalStorageDevices: additionalStorageDevices,
                                                 directorySharingDevices: directorySharingDevices,
                                                 serialPorts: serialPorts
     )
@@ -277,7 +280,7 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     nvramURL: URL,
     vmConfig: VMConfig,
     network: Network = NetworkShared(),
-    additionalDiskAttachments: [VZDiskImageStorageDeviceAttachment],
+    additionalStorageDevices: [VZStorageDeviceConfiguration],
     directorySharingDevices: [VZDirectorySharingDeviceConfiguration],
     serialPorts: [VZSerialPortConfiguration],
     suspendable: Bool = false
@@ -326,11 +329,11 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     }
 
     // Storage
-    var attachments = [try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false)]
-    attachments.append(contentsOf: additionalDiskAttachments)
-    configuration.storageDevices = attachments.map {
-      VZVirtioBlockDeviceConfiguration(attachment: $0)
-    }
+    var devices: [VZStorageDeviceConfiguration] = [
+      VZVirtioBlockDeviceConfiguration(attachment: try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false))
+    ]
+    devices.append(contentsOf: additionalStorageDevices)
+    configuration.storageDevices = devices
 
     // Entropy
     if !suspendable {

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -11,9 +11,6 @@ struct NoMainScreenFoundError: Error {
 struct DownloadFailed: Error {
 }
 
-struct CanNotAccessBlockDevice: Error {
-}
-
 struct UnsupportedOSError: Error, CustomStringConvertible {
   let description: String
 


### PR DESCRIPTION
This way AWS customers will be able to benefit from fast local SSDs on the machines. Right now a EC2 Mac Instances is booted from a EBS volume which is fast but is not as fast as a local SSD. Running Tart VMs of the EBS volume totally works but for advanced integrators it might be reasonable to mount a local SSD as a disk to a VM and run their workloads on it.

There are a few caveats to this use case:

1. Block devices persist state and should be cleaned up.
2. `tart` binary should be run as root to access disks in `/dev`.
3. Only Sonoma hosts are supported. Ventura guests are fine.
4. A block device can only be attached to a single VM.

PS I tried but failed miserably to find a way to escalate permissions to open a file descriptor for the disk with `root` permission out of Tart process running as a user.