### PR TITLE
Support mounting remote archives

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -609,14 +609,14 @@ func sanitizeDirectoryShareConfiguration(createFrom: String) throws -> String {
   let namePart = createFrom.prefix(upTo: urlStartIndex!)
   let archiveUrl: String = createFrom.suffix(from: urlStartIndex!).replacingOccurrences(of: ":ro", with: "")
 
-  let archiveRequest = URLRequest(url: URL(string: archiveUrl)!)
+  let archiveRequest = URLRequest(url: URL(string: archiveUrl)!, cachePolicy: .returnCacheDataElseLoad)
   var response: CachedURLResponse? = URLCache.shared.cachedResponse(for: archiveRequest)
   if (response == nil) {
     print("Downloading \(archiveUrl)...")
     let downloadSemaphore = DispatchSemaphore(value: 0)
     Task {
       let (archiveData, archiveResponse) = try await URLSession.shared.data(for: archiveRequest)
-      URLCache.shared.storeCachedResponse(CachedURLResponse(response: archiveResponse, data: archiveData), for: archiveRequest)
+      URLCache.shared.storeCachedResponse(CachedURLResponse(response: archiveResponse, data: archiveData, storagePolicy: .allowed), for: archiveRequest)
       print("Cached for future invocations!")
       downloadSemaphore.signal()
     }

--- a/Tests/TartTests/DirecotryShareTests.swift
+++ b/Tests/TartTests/DirecotryShareTests.swift
@@ -3,28 +3,28 @@ import XCTest
 
 final class DirectoryShareTests: XCTestCase {
   func testNamedParsing() throws {
-    let share = try DirectoryShare(parseFrom: "build:/Users/admin/build")
+    let share = try DirectoryShare(createFrom: "build:/Users/admin/build")
     XCTAssertEqual(share.name, "build")
     XCTAssertEqual(share.path, URL(filePath: "/Users/admin/build"))
     XCTAssertFalse(share.readOnly)
   }
   
   func testNamedReadOnlyParsing() throws {
-    let share = try DirectoryShare(parseFrom: "build:/Users/admin/build:ro")
+    let share = try DirectoryShare(createFrom: "build:/Users/admin/build:ro")
     XCTAssertEqual(share.name, "build")
     XCTAssertEqual(share.path, URL(filePath: "/Users/admin/build"))
     XCTAssertTrue(share.readOnly)
   }
   
   func testOptionalNameParsing() throws {
-    let share = try DirectoryShare(parseFrom: "/Users/admin/build")
+    let share = try DirectoryShare(createFrom: "/Users/admin/build")
     XCTAssertNil(share.name)
     XCTAssertEqual(share.path, URL(filePath: "/Users/admin/build"))
     XCTAssertFalse(share.readOnly)
   }
   
   func testOptionalNameReadOnlyParsing() throws {
-    let share = try DirectoryShare(parseFrom: "/Users/admin/build:ro")
+    let share = try DirectoryShare(createFrom: "/Users/admin/build:ro")
     XCTAssertNil(share.name)
     XCTAssertEqual(share.path, URL(filePath: "/Users/admin/build"))
     XCTAssertTrue(share.readOnly)

--- a/Tests/TartTests/DirecotryShareTests.swift
+++ b/Tests/TartTests/DirecotryShareTests.swift
@@ -3,28 +3,28 @@ import XCTest
 
 final class DirectoryShareTests: XCTestCase {
   func testNamedParsing() throws {
-    let share = try DirectoryShare(createFrom: "build:/Users/admin/build")
+    let share = try DirectoryShare(parseFrom: "build:/Users/admin/build")
     XCTAssertEqual(share.name, "build")
     XCTAssertEqual(share.path, URL(filePath: "/Users/admin/build"))
     XCTAssertFalse(share.readOnly)
   }
   
   func testNamedReadOnlyParsing() throws {
-    let share = try DirectoryShare(createFrom: "build:/Users/admin/build:ro")
+    let share = try DirectoryShare(parseFrom: "build:/Users/admin/build:ro")
     XCTAssertEqual(share.name, "build")
     XCTAssertEqual(share.path, URL(filePath: "/Users/admin/build"))
     XCTAssertTrue(share.readOnly)
   }
   
   func testOptionalNameParsing() throws {
-    let share = try DirectoryShare(createFrom: "/Users/admin/build")
+    let share = try DirectoryShare(parseFrom: "/Users/admin/build")
     XCTAssertNil(share.name)
     XCTAssertEqual(share.path, URL(filePath: "/Users/admin/build"))
     XCTAssertFalse(share.readOnly)
   }
   
   func testOptionalNameReadOnlyParsing() throws {
-    let share = try DirectoryShare(createFrom: "/Users/admin/build:ro")
+    let share = try DirectoryShare(parseFrom: "/Users/admin/build:ro")
     XCTAssertNil(share.name)
     XCTAssertEqual(share.path, URL(filePath: "/Users/admin/build"))
     XCTAssertTrue(share.readOnly)


### PR DESCRIPTION
Allow to pass an HTTPS link instead of a local path to `tart run --dir` argument. HTTPS link should point to a gzipped Tar archive aka `*.tar.gz` file.

In this situation Tart will download an archive by the link if necessary, will cache it and will unarchive it into a temporary folder inside `$TART_HOME` to be mounted to the VM.

This use case is useful for mounting something external that updates faster than the VM itself. For example, GitHub Actions Runner installation.