### PR TITLE
Fetcher.fetchViaFile(): use an mmap(2)-ed file, similarly to DiskV1

### DIFF
--- a/Sources/tart/Fetcher.swift
+++ b/Sources/tart/Fetcher.swift
@@ -35,12 +35,12 @@ class Fetcher {
     //
     // This keeps a working reference to that file, yet we don't
     // have to deal with the cleanup any more.
-    let fh = try FileHandle(forReadingFrom: fileURL)
+    let mappedFile = try Data(contentsOf: fileURL, options: [.alwaysMapped])
     try FileManager.default.removeItem(at: fileURL)
 
     Task {
-      while let data = try fh.read(upToCount: 64 * 1024 * 1024) {
-        await dataCh.send(data)
+      for chunk in (0 ..< mappedFile.count).chunks(ofCount: 64 * 1024 * 1024) {
+        await dataCh.send(mappedFile.subdata(in: chunk))
       }
 
       dataCh.finish()

--- a/Sources/tart/OCI/Registry.swift
+++ b/Sources/tart/OCI/Registry.swift
@@ -253,7 +253,7 @@ class Registry {
     for try await part in channel {
       try Task.checkCancellation()
 
-      try await handler(Data(part))
+      try await handler(part)
     }
   }
 


### PR DESCRIPTION
Should help with the memory usage when `pull`'ing.