### PR TITLE
tart-dev.entitlements: add "com.apple.security.get-task-allow"

### DIFF
--- a/Resources/tart-dev.entitlements
+++ b/Resources/tart-dev.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.virtualization</key>
 	<true/>
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Needed to run the Tart in the Instruments.app, otherwise Instruments.app will report an error.