### PR TITLE
Don't install Sentry CLI via brew

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -83,8 +83,9 @@ task:
     - security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k password101 build.keychain
     - xcrun notarytool store-credentials "notarytool" --apple-id "hello@cirruslabs.org" --team-id "9M2P8L4D89" --password $AC_PASSWORD
   install_script:
-    - brew install go goreleaser/tap/goreleaser-pro getsentry/tools/sentry-cli
+    - brew install go goreleaser/tap/goreleaser-pro
     - brew install mitchellh/gon/gon
+    - curl -sL https://sentry.io/get-cli/ | sh
   info_script:
     - security find-identity -v
     - xcodebuild -version


### PR DESCRIPTION
Seems it installas 1.x version instead of 2.x. Sentry's documentation [recommends to use their script](https://docs.sentry.io/product/cli/installation/?original_referrer=https%3A%2F%2Fwww.google.com%2F#automatic-installation).