### PR TITLE
fix docs to specify inside VM for gitlab runner

### DIFF
--- a/docs/integrations/gitlab-runner.md
+++ b/docs/integrations/gitlab-runner.md
@@ -19,7 +19,7 @@ concurrent = 2
 [[runners]]
   # ...
   executor = "custom"
-  builds_dir = "/Users/admin/builds" # directory inside the 
+  builds_dir = "/Users/admin/builds" # directory inside the VM
   cache_dir = "/Users/admin/cache"
   [runners.feature_flags]
     FF_RESOLVE_FULL_TLS_CHAIN = false


### PR DESCRIPTION
Simply just adds specifically VM in the gitlab runner docs to avoid confusion of where the build and cache dirs are.

Some context for this - when I initially read it I took no notice and changed the dirs to be something like `/Users/ec2-user/...` and it broke, so just a simple improvement to the docs.

Thanks!