### PR TITLE
Hide dock icon in no graphics mode

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -312,8 +312,11 @@ struct Run: AsyncParsableCommand {
 
     let useVNCWithoutGraphics = (vnc || vncExperimental) && !graphics
     if noGraphics || useVNCWithoutGraphics {
-      // enter the main even loop and just wait for the VM to exit
-      NSApplication.shared.run()
+      // enter the main even loop, without bringing up any UI,
+      // and just wait for the VM to exit.
+      let nsApp = NSApplication.shared
+      nsApp.setActivationPolicy(.prohibited)
+      nsApp.run()
     } else {
       runUI(suspendable, captureSystemKeys)
     }

--- a/scripts/run-signed.sh
+++ b/scripts/run-signed.sh
@@ -8,4 +8,8 @@ set -e
 swift build --product tart
 codesign --sign - --entitlements Resources/tart-dev.entitlements --force .build/debug/tart
 
-.build/debug/tart "$@"
+mkdir -p .build/tart.app/Contents/MacOS
+cp -c .build/debug/tart .build/tart.app/Contents/MacOS/tart
+cp -c Resources/embedded.provisionprofile .build/tart.app/Contents/embedded.provisionprofile
+
+.build/tart.app/Contents/MacOS/tart "$@"


### PR DESCRIPTION
This was likely not caught because the `run-signed.sh` script used during development didn't wrap the executable in an application bundle, which is what's done when Tart is installed on user systems.

The app bundle triggers macOS to show a Dock icon, which we now hide explicitly by setting an activation policy of prohibited:

https://developer.apple.com/documentation/appkit/nsapplication/activationpolicy/prohibited