### PR TITLE
OCI storage: unconditionally remove the old link when link()'ing

### DIFF
--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -219,9 +219,7 @@ class VMStorageOCI: PrunableStorage {
   }
 
   func link(from: RemoteName, to: RemoteName) throws {
-    if FileManager.default.fileExists(atPath: vmURL(from).path) {
-      try FileManager.default.removeItem(at: vmURL(from))
-    }
+    try? FileManager.default.removeItem(at: vmURL(from))
 
     try FileManager.default.createSymbolicLink(at: vmURL(from), withDestinationURL: vmURL(to))
 


### PR DESCRIPTION
The [`fileExists()`](https://developer.apple.com/documentation/foundation/filemanager/1415645-fileexists) method always resolves symbolic links and will return `false` even if the link itself exists:

>If the final element in path specifies a symbolic link, this method traverses the link and returns true or false based on the existence of the file at the link destination.

This is an issue when `tart pull` detects that there isn't enough space for the new image, removes the old `sha256:` and then tries to create a link for the news image and fails:

>Persistent worker failed to start the task: tart isolation failed: failed to create VM cloned from "[ghcr.io/cirruslabs/macos-sonoma-base:latest](http://ghcr.io/cirruslabs/macos-sonoma-base:latest)": tart command returned non-zero exit code: "Error: The file “latest” couldn’t be saved in the folder “macos-sonoma-base” because a file with the same name already exists.”

Unfortunately, the [FileManager](https://developer.apple.com/documentation/foundation/filemanager) doesn't seem to provide any alternatives that don't follow the link, so the only way is to use raw system calls 🤦 

I think a more easier solution would be to simply always delete the old link and ignore the errors (e.g. when an old link doesn't exist).

Resolves [PERSISTENT-WORKERS-1T](https://cirrus-labs.sentry.io/issues/PERSISTENT-WORKERS-1T).