### PR TITLE
tart create --from-ipsw: expand tilde (~) in path

### DIFF
--- a/Sources/tart/Commands/Create.swift
+++ b/Sources/tart/Commands/Create.swift
@@ -40,7 +40,7 @@ struct Create: AsyncParsableCommand {
         } else if fromIPSW.starts(with: "http://") || fromIPSW.starts(with: "https://") {
           ipswURL = URL(string: fromIPSW)!
         } else {
-          ipswURL = URL(fileURLWithPath: fromIPSW)
+          ipswURL = URL(fileURLWithPath: NSString(string: fromIPSW).expandingTildeInPath)
         }
 
         _ = try await VM(vmDir: tmpVMDir, ipswURL: ipswURL, diskSizeGB: diskSize)


### PR DESCRIPTION
So that invocation like `tart create macos --from-ipsw=~/UniversalMac_14.1_23B74_Restore.ipsw` would work.