### PR TITLE
Some SEO optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Built by CI engineers for your automation needs. Here are some highlights of Tar
 * Use Tart Packer Plugin to automate VM creation.
 * Easily integrates with any CI system.
 
-Tart powers [Cirrus Runners](https://tart.run/integrations/github-actions/?utm_source=github&utm_medium=referral)
+Tart powers [Cirrus Runners](https://cirrus-runners.app/)
 service — a drop-in replacement for the standard GitHub-hosted runners, offering 2-3 times better performance for a fraction of the price.
 
 <p align="center">
@@ -17,21 +17,7 @@ service — a drop-in replacement for the standard GitHub-hosted runners, offeri
   </a>
 </p>
 
-Tart is also adopted by several other automation services:
-
-<p align="center">
-  <a href="https://cirrus-ci.org/guide/macOS/" target=_blank>
-    <img src="https://github.com/cirruslabs/tart/raw/main/Resources/Users/CirrusCI.png" height="65"/>
-  </a>
-  <a href="https://codemagic.io/" target=_blank>
-    <img src="https://github.com/cirruslabs/tart/raw/main/Resources/Users/Codemagic.png" height="65"/>
-  </a>
-  <a href="https://testingbot.com/" target=_blank>
-    <img src="https://github.com/cirruslabs/tart/raw/main/Resources/Users/TestingBot.png" height="65"/>
-  </a>
-</p>
-
-Many more companies are using Tart in their internal setups. Here are a few of them:
+Many companies are using Tart in their internal setups. Here are a few of them:
 
 <p align="center">
   <a href="https://ahrefs.com/" target=_blank>

--- a/docs/theme/overrides/home.html
+++ b/docs/theme/overrides/home.html
@@ -171,15 +171,10 @@
           <figcaption class="md-typeset">
             <h2>Seamless integration with your existing automations</h2>
             <p>
-              Tart powers several continuous integration systems including
-              <a href="/integrations/github-actions"
-              >on&#8209;demand GitHub Actions Runners</a
-              >
-              and
-              <a href="https://cirrus-ci.org/guide/macOS/" target="_blank"
-              >Cirrus&nbsp;CI</a
-              >. Double the performance of&nbsp;your macOS actions with
-              a&nbsp;couple lines of&nbsp;code.
+              Tart integrates with many continuous integration systems, including a dedicated
+              service of on-demand GitHub Actions Runners. With a single line change, you can cut your
+              CI/CD costs by up to <b>30 times</b> by using <a href="https://cirrus-runners.app/">Cirrus Runners</a>
+              to run your workflows.
             </p>
           </figcaption>
         </figure>
@@ -280,7 +275,7 @@
           <figcaption class="md-typeset">
             <h2>Mitchell Hashimoto</h2>
             <h3>
-              HashiCorp co-founder
+              <a href="https://www.hashicorp.com/" target="_blank">HashiCorp</a> co-founder
             </h3>
             <hr/>
             <cite>
@@ -291,25 +286,25 @@
         </figure>
         <figure class="mdx-users__testimonial">
           <img
-            src="assets/images/users/mikhail-tokarev.webp"
-            alt="Mikhail Tokarev"
+            src="assets/images/users/seb-jachec.webp"
+            alt="Sebastian Jachec"
             loading="lazy"
             width="200"
             height="200"
           />
           <figcaption class="md-typeset">
-            <h2>Mikhail Tokarev</h2>
+            <h2>Sebastian Jachec</h2>
             <h3>
-              CTO at
-              <a href="https://codemagic.io/start/" target="_blank"
-              >Codemagic</a
-              >
+              Mobile Engineer at
+              <a href="https://daybridge.com/" target="_blank">Daybridge</a>
             </h3>
             <hr/>
             <cite>
-              Thanks to the minimal overhead of using the Apple Virtualization
-              API, we’ve seen some performance improvements in booting new
-              virtual machines compared with Anka.
+              It&rsquo;s been plain-sailing with the
+              <a href="/integrations/github-actions">Cirrus Runners</a>&nbsp;&mdash;
+              they&rsquo;ve been great! They&rsquo;re consistently&nbsp;60+%
+              faster on&nbsp;workflows that we&nbsp;previously used Github
+              Actions&rsquo; macOS runners for.
             </cite>
           </figcaption>
         </figure>


### PR DESCRIPTION
Removed Anka mentions and Codemagic/Testingbot since we don't know if they still use Tart.