### PR TITLE
Improve rename error message

### DIFF
--- a/Sources/tart/Commands/Rename.swift
+++ b/Sources/tart/Commands/Rename.swift
@@ -24,7 +24,7 @@ struct Rename: AsyncParsableCommand {
     }
 
     if localStorage.exists(newName) {
-      throw ValidationError("failed to rename VM \(name), target VM \(name) already exists, delete it first!")
+      throw ValidationError("failed to rename VM \(name), target VM \(newName) already exists, delete it first!")
     }
 
     try localStorage.rename(name, newName)


### PR DESCRIPTION
This seems like the intention of the error message, it should show the name of the VM that you are trying to set as the new name.

If you run:
`tart rename firstVM secondVM`

It currently prints:
`failed to rename VM firstVM, target VM firstVM already exists`

Now it will print:
`failed to rename VM firstVM, target VM secondVM already exists`