### PR TITLE
Add command line option to run without audio

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -36,6 +36,9 @@ struct Run: AsyncParsableCommand {
   @Flag(help: "Force open a UI window, even when VNC is enabled.")
   var graphics: Bool = false
 
+  @Flag(help: "Disable audio pass-through to host.")
+  var noAudio: Bool = false
+
   #if arch(arm64)
     @Flag(help: "Boot into recovery mode")
   #endif
@@ -210,7 +213,8 @@ struct Run: AsyncParsableCommand {
       additionalStorageDevices: additionalDiskAttachments,
       directorySharingDevices: directoryShares() + rosettaDirectoryShare(),
       serialPorts: serialPorts,
-      suspendable: suspendable
+      suspendable: suspendable,
+      audio: !noAudio
     )
 
     let vncImpl: VNC? = try {

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -45,7 +45,8 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
        additionalStorageDevices: [VZStorageDeviceConfiguration] = [],
        directorySharingDevices: [VZDirectorySharingDeviceConfiguration] = [],
        serialPorts: [VZSerialPortConfiguration] = [],
-       suspendable: Bool = false
+       suspendable: Bool = false,
+       audio: Bool = true
   ) throws {
     name = vmDir.name
     config = try VMConfig.init(fromURL: vmDir.configURL)
@@ -61,7 +62,8 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
                                                 network: network, additionalStorageDevices: additionalStorageDevices,
                                                 directorySharingDevices: directorySharingDevices,
                                                 serialPorts: serialPorts,
-                                                suspendable: suspendable
+                                                suspendable: suspendable,
+                                                audio: audio
     )
     virtualMachine = VZVirtualMachine(configuration: configuration)
 
@@ -274,7 +276,8 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     additionalStorageDevices: [VZStorageDeviceConfiguration],
     directorySharingDevices: [VZDirectorySharingDeviceConfiguration],
     serialPorts: [VZSerialPortConfiguration],
-    suspendable: Bool = false
+    suspendable: Bool = false,
+    audio: Bool = true
   ) throws -> VZVirtualMachineConfiguration {
     let configuration = VZVirtualMachineConfiguration()
 
@@ -292,7 +295,7 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     configuration.graphicsDevices = [vmConfig.platform.graphicsDevice(vmConfig: vmConfig)]
 
     // Audio
-    if !suspendable {
+    if audio && !suspendable {
       let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
       let inputAudioStreamConfiguration = VZVirtioSoundDeviceInputStreamConfiguration()
       inputAudioStreamConfiguration.source = VZHostAudioInputStreamSource()


### PR DESCRIPTION
The default behavior is to run with audio if we're showing the Tart UI window. It can be disabled with --no-audio.

When running without a UI Window, audio is disabled, but can be enabled via --audio.