### PR TITLE
Do not magically set `--no-graphics` when `--vnc` is passed

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -33,7 +33,7 @@ struct Run: AsyncParsableCommand {
   ))
   var serialPath: String?
 
-  @Flag(help: "Force open a UI window, even when VNC is enabled.")
+  @Flag(help: ArgumentHelp("Force open a UI window, even when VNC is enabled.", visibility: .hidden))
   var graphics: Bool = false
 
   #if arch(arm64)
@@ -133,8 +133,8 @@ struct Run: AsyncParsableCommand {
       throw ValidationError("--net-bridged and --net-softnet are mutually exclusive")
     }
 
-    if graphics && noGraphics {
-      throw ValidationError("--graphics and --no-graphics are mutually exclusive")
+    if graphics {
+      print("--graphics is deprecated and will be removed in the future.\n")
     }
 
     if (noGraphics || vnc || vncExperimental) && captureSystemKeys {
@@ -332,8 +332,7 @@ struct Run: AsyncParsableCommand {
     }
     sigusr1Src.activate()
 
-    let useVNCWithoutGraphics = (vnc || vncExperimental) && !graphics
-    if noGraphics || useVNCWithoutGraphics {
+    if noGraphics {
       // enter the main even loop, without bringing up any UI,
       // and just wait for the VM to exit.
       let nsApp = NSApplication.shared


### PR DESCRIPTION
From a discussion in #728 it appeared that having both `--graphics` and `--no-graphics` is a bit confusing.

`--graphics` was introduced in #248 to support having both VNC and UI for debugging Packer plugin in cirruslabs/packer-plugin-tart#21. This is because `--vnc` flag has a side effect of hiding UI which I think was wrong in retrospective. One can run `tart run --vnc --no-graphics`. In most of the cases this is automated via Alfred or something like that.

Now we have so many arguments that IMO it's worth to remove `--graphics` for overall consistency in arguments: everything is enabled by default and can be disabled via `--no-*` flags.