### PR TITLE
Simpler DirectoryShare parsing and --dir documentation improvements

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -91,7 +91,7 @@ struct Run: AsyncParsableCommand {
   @Option(help: ArgumentHelp("Additional directory shares with an optional read-only and mount tag options (e.g. --dir=\"~/src/build\" or --dir=\"~/src/sources:ro\")", discussion: """
   Requires host to be macOS 13.0 (Ventura) or newer. macOS guests must be running macOS 13.0 (Ventura) or newer too.
 
-  Options are as follows:
+  Options are comma-separated and are as follows:
 
   * ro — mount this directory share in read-only mode instead of the default read-write (e.g. --dir=\"~/src/sources:ro\")
 

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -669,12 +669,12 @@ struct DirectoryShare {
 
     let arguments = parseFrom.split(separator: ":", maxSplits: 1)
 
-    if arguments.count == 1 {
-      self.name = nil
-      self.path = String(arguments[0]).toRemoteOrLocalURL()
-    } else {
+    if arguments.count == 2 {
       self.name = String(arguments[0])
       self.path = String(arguments[1]).toRemoteOrLocalURL()
+    } else {
+      self.name = nil
+      self.path = String(arguments[0]).toRemoteOrLocalURL()
     }
   }
 

--- a/Tests/TartTests/DirecotryShareTests.swift
+++ b/Tests/TartTests/DirecotryShareTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 @testable import tart
 
+import Virtualization
+
 final class DirectoryShareTests: XCTestCase {
   func testNamedParsing() throws {
     let share = try DirectoryShare(parseFrom: "build:/Users/admin/build")
@@ -43,5 +45,25 @@ final class DirectoryShareTests: XCTestCase {
     XCTAssertEqual(roShare.path, URL(filePath: "/Users/admin/build"))
     XCTAssertTrue(roShare.readOnly)
     XCTAssertEqual(roShare.mountTag, "foo-bar")
+  }
+
+  func testURL() throws {
+    let archiveWithoutNameOrOptions = try DirectoryShare(parseFrom: "https://example.com/archive.tar.gz")
+    XCTAssertNil(archiveWithoutNameOrOptions.name)
+    XCTAssertEqual(archiveWithoutNameOrOptions.path, URL(string: "https://example.com/archive.tar.gz")!)
+    XCTAssertFalse(archiveWithoutNameOrOptions.readOnly)
+    XCTAssertEqual(archiveWithoutNameOrOptions.mountTag, VZVirtioFileSystemDeviceConfiguration.macOSGuestAutomountTag)
+
+    let archiveWithOptions = try DirectoryShare(parseFrom: "https://example.com/archive.tar.gz:ro,tag=sometag")
+    XCTAssertNil(archiveWithOptions.name)
+    XCTAssertEqual(archiveWithOptions.path, URL(string: "https://example.com/archive.tar.gz")!)
+    XCTAssertTrue(archiveWithOptions.readOnly)
+    XCTAssertEqual(archiveWithOptions.mountTag, "sometag")
+
+    let archiveWithNameAndOptions = try DirectoryShare(parseFrom: "somename:https://example.com/archive.tar.gz:ro,tag=sometag")
+    XCTAssertEqual(archiveWithNameAndOptions.name, "somename")
+    XCTAssertEqual(archiveWithNameAndOptions.path, URL(string: "https://example.com/archive.tar.gz")!)
+    XCTAssertTrue(archiveWithNameAndOptions.readOnly)
+    XCTAssertEqual(archiveWithNameAndOptions.mountTag, "sometag")
   }
 }

--- a/Tests/TartTests/DirecotryShareTests.swift
+++ b/Tests/TartTests/DirecotryShareTests.swift
@@ -39,12 +39,17 @@ final class DirectoryShareTests: XCTestCase {
     XCTAssertFalse(share.readOnly)
     XCTAssertEqual(share.mountTag, "foo-bar")
 
-
     let roShare = try DirectoryShare(parseFrom: "/Users/admin/build:ro,tag=foo-bar")
     XCTAssertNil(roShare.name)
     XCTAssertEqual(roShare.path, URL(filePath: "/Users/admin/build"))
     XCTAssertTrue(roShare.readOnly)
     XCTAssertEqual(roShare.mountTag, "foo-bar")
+
+    let inverseRoShare = try DirectoryShare(parseFrom: "/Users/admin/build:tag=foo-bar,ro")
+    XCTAssertNil(inverseRoShare.name)
+    XCTAssertEqual(inverseRoShare.path, URL(filePath: "/Users/admin/build"))
+    XCTAssertTrue(inverseRoShare.readOnly)
+    XCTAssertEqual(inverseRoShare.mountTag, "foo-bar")
   }
 
   func testURL() throws {


### PR DESCRIPTION
This reduces the cognitive complexity of `DirectoryShare` parsing code by moving the options parsing logic (`ro` and `tag`) into a separate method and also allows specifying options in any order (e.g. `/Users/admin/build:tag=foo-bar,ro`).

Also, the docs for `--dir` now looks like this:

<img width="1476" alt="Screenshot 2024-02-19 at 23 43 28" src="https://github.com/cirruslabs/tart/assets/85709/fc9bb25d-87ce-4185-8c81-60b0b596ac0f">

The `[name:]path[:ro,tag=virtiofs-mount-tag]` format unfortunately does not allow us to express the available option combinations properly, so I think it would be a nice idea to reduce the cognitive load and abstract away the notion of "options" altogether into `discussion` section.