### PR TITLE
DHCP MAC-address resolver: handle duplicate leases

### DIFF
--- a/Sources/tart/MACAddressResolver/Leases.swift
+++ b/Sources/tart/MACAddressResolver/Leases.swift
@@ -45,7 +45,10 @@ class Leases {
       (lease.mac, lease)
     })
 
-    self.leases = Dictionary(uniqueKeysWithValues: leases)
+    self.leases = Dictionary(leases) { (left, right) in
+      // When duplicate lease is found, prefer a newer lease over the older one
+      (left.expiresAt > right.expiresAt) ? left : right
+    }
   }
 
   /// Parse leases from the host cache similarly to the PLCache_read() function found in Apple's Open Source releases.

--- a/Tests/TartTests/LeasesTests.swift
+++ b/Tests/TartTests/LeasesTests.swift
@@ -35,4 +35,27 @@ final class LeasesTests: XCTestCase {
 
     XCTAssertEqual(IPv4Address("1.2.3.4"), leases.ResolveMACAddress(macAddress: macAddress))
   }
+
+  func testDuplicateYetNotExpiredLeases() throws {
+    let macAddress = MACAddress(fromString: "11:22:33:44:55:66")!
+
+    let leases = try Leases("""
+    {
+            name=debian
+            ip_address=192.168.64.1
+            hw_address=1,\(macAddress)
+            identifier=1,\(macAddress)
+            lease=\(Int((Date() + 10.minutes).timeIntervalSince1970).hex)
+    }
+    {
+            name=debian
+            ip_address=192.168.64.2
+            hw_address=1,\(macAddress)
+            identifier=1,\(macAddress)
+            lease=\(Int((Date() + 5.minutes).timeIntervalSince1970).hex)
+    }
+    """)
+
+    XCTAssertEqual(IPv4Address("192.168.64.1"), leases.ResolveMACAddress(macAddress: macAddress))
+  }
 }


### PR DESCRIPTION
Before we were *trying* to handle condition this by filtering out expired leases: https://github.com/cirruslabs/tart/blob/3f17884ac2bdba56f5688537aa6da4d14533e3f4/Sources/tart/MACAddressResolver/Leases.swift#L42-L44

However, it seems that it's possible to have two un-expired leases for the same MAC-address at the same time.

So let's prefer a newer lease over the older one when a duplicate is found.

See https://github.com/cirruslabs/tart/issues/739 for more details.