### PR TITLE
Prefer USB keyboard and screen coordinate pointing devices

### DIFF
--- a/Sources/tart/Platform/Darwin.swift
+++ b/Sources/tart/Platform/Darwin.swift
@@ -103,7 +103,7 @@ struct UnsupportedHostOSError: Error, CustomStringConvertible {
     func keyboards() -> [VZKeyboardConfiguration] {
       if #available(macOS 14, *) {
         // Mac keyboard is only supported by guests starting with macOS Ventura
-        return [VZMacKeyboardConfiguration(), VZUSBKeyboardConfiguration()]
+        return [VZUSBKeyboardConfiguration(), VZMacKeyboardConfiguration()]
       } else {
         return [VZUSBKeyboardConfiguration()]
       }
@@ -120,7 +120,7 @@ struct UnsupportedHostOSError: Error, CustomStringConvertible {
 
     func pointingDevices() -> [VZPointingDeviceConfiguration] {
       // Trackpad is only supported by guests starting with macOS Ventura
-      [VZMacTrackpadConfiguration(), VZUSBScreenCoordinatePointingDeviceConfiguration()]
+      [VZUSBScreenCoordinatePointingDeviceConfiguration(), VZMacTrackpadConfiguration()]
     }
 
     func pointingDevicesSuspendable() -> [VZPointingDeviceConfiguration] {


### PR DESCRIPTION
It seems that the experimental VNC server uses a different code path and only considers the first input device in list, which causes the VNC to not process any input on macOS Monterey guests.

Tested on `UniversalMac_12.6.1_21G217_Restore.ipsw`, resolves https://github.com/cirruslabs/packer-plugin-tart/issues/128.

I've also checked that the previous/next page gesture works on macOS Sonoma guests in Safari.

Needs fixes from https://github.com/cirruslabs/tart/pull/746 for the build to succeed.