### PR TITLE
Lowercase `tart.app`

### DIFF
--- a/.ci/pkg/scripts/postinstall
+++ b/.ci/pkg/scripts/postinstall
@@ -3,13 +3,13 @@
 set -e
 
 # fix structure
-mkdir -p "$2/Tart.app/Contents/MacOS" "$2/Tart.app/Resources"
-mv "$2/tart" "$2/Tart.app/Contents/MacOS/tart"
-mv "$2/embedded.provisionprofile" "$2/Tart.app/Contents/embedded.provisionprofile"
-mv "$2/AppIcon.png" "$2/Tart.app/Resources/AppIcon.png"
-mv "$2/Info.plist" "$2/Tart.app/Contents/Info.plist"
+mkdir -p "$2/tart.app/Contents/MacOS" "$2/tart.app/Resources"
+mv "$2/tart" "$2/tart.app/Contents/MacOS/tart"
+mv "$2/embedded.provisionprofile" "$2/tart.app/Contents/embedded.provisionprofile"
+mv "$2/AppIcon.png" "$2/tart.app/Resources/AppIcon.png"
+mv "$2/Info.plist" "$2/tart.app/Contents/Info.plist"
 
 echo "#!/bin/sh" > /usr/local/bin/tart
-echo "exec '$2/Tart.app/Contents/MacOS/tart' \"\$@\"" >> /usr/local/bin/tart
+echo "exec '$2/tart.app/Contents/MacOS/tart' \"\$@\"" >> /usr/local/bin/tart
 
 chmod +x /usr/local/bin/tart

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleName</key>
-    <string>Tart</string>
+    <string>tart</string>
     <key>CFBundleIdentifier</key>
     <string>org.cirruslabs.tart</string>
     <key>CFBundleExecutable</key>

--- a/scripts/run-signed.sh
+++ b/scripts/run-signed.sh
@@ -8,11 +8,11 @@ set -e
 swift build --product tart
 codesign --sign - --entitlements Resources/tart-dev.entitlements --force .build/debug/tart
 
-rm -Rf .build/Tart.app/
-mkdir -p .build/Tart.app/Contents/MacOS .build/Tart.app/Contents/Resources
-cp -c .build/debug/tart .build/Tart.app/Contents/MacOS/tart
-cp -c Resources/embedded.provisionprofile .build/Tart.app/Contents/embedded.provisionprofile
-cp -c Resources/Info.plist .build/Tart.app/Contents/Info.plist
-cp -c Resources/AppIcon.png .build/Tart.app/Contents/Resources
+rm -Rf .build/tart.app/
+mkdir -p .build/tart.app/Contents/MacOS .build/tart.app/Contents/Resources
+cp -c .build/debug/tart .build/tart.app/Contents/MacOS/tart
+cp -c Resources/embedded.provisionprofile .build/tart.app/Contents/embedded.provisionprofile
+cp -c Resources/Info.plist .build/tart.app/Contents/Info.plist
+cp -c Resources/AppIcon.png .build/tart.app/Contents/Resources
 
-.build/Tart.app/Contents/MacOS/tart "$@"
+.build/tart.app/Contents/MacOS/tart "$@"


### PR DESCRIPTION
So signing and `embedded.provisionprofile` work as expected.

Related to #746