### PR TITLE
integration-tests: test_run() with --no-graphics

### DIFF
--- a/integration-tests/test_run.py
+++ b/integration-tests/test_run.py
@@ -1,16 +1,18 @@
 import uuid
 
+import pytest
 from paramiko.client import SSHClient, AutoAddPolicy
 
 
-def test_run(tart):
+@pytest.mark.parametrize("run_opts", [[], ["--no-graphics"]])
+def test_run(tart, run_opts):
     vm_name = f"integration-test-run-{uuid.uuid4()}"
 
     # Instantiate a VM with admin:admin SSH access
     tart.run(["clone", "ghcr.io/cirruslabs/macos-sonoma-base:latest", vm_name])
 
     # Run the VM asynchronously
-    tart_run_process = tart.run_async(["run", vm_name])
+    tart_run_process = tart.run_async(["run", vm_name] + run_opts)
 
     # Obtain the VM's IP
     stdout, _ = tart.run(["ip", vm_name, "--wait", "120"])


### PR DESCRIPTION
This could've detected the regression introduced in https://github.com/cirruslabs/tart/pull/746.