### PR TITLE
Restore behavior of --vnc and --vnc-experimental to disable default UI

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -349,7 +349,7 @@ struct Run: AsyncParsableCommand {
     }
     sigusr1Src.activate()
 
-    if noGraphics {
+    if noGraphics || vnc || vncExperimental {
       // enter the main even loop, without bringing up any UI,
       // and just wait for the VM to exit.
       NSApplication.shared.run()


### PR DESCRIPTION
Otherwise we end up with two UI windows with --vnc or --vnc-experimental, one for the built in UI and one for the Screen Sharing connection.

Disabling the built in UI window via --no-graphics in this situation is not ideal, as it also disables the convenience of Tart automatically opening Screen Sharing with the right address and password.

Restoring the behavior allows the choice of headless or not via --no-graphcis to be made independently of how the UI is provided, either via the default UI, or via Screen Sharing / VNC.

The --graphics option is still deprecated, to keep the command line options from running wild.

See #732