### PR TITLE
Fix the --insecure flag issue by disabling ATS in Info.plist

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -14,5 +14,10 @@
     <array>
         <string>AppIcon.png</string>
     </array>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
After upgrading tart to version 2.7.0, I encountered an issue with the `--insecure` flag.

```
➜  ~ tart push tart-build --insecure macregistry.example.com/macos/sonoma
pushing tart-build to macregistry.example.com/macos/sonoma:latest...
pushing config...
Error: The resource could not be loaded because the App Transport Security policy requires the use of a secure connection.
```

I managed to fix it by disabling App Transport Security. I'm not sure this is the best approach, but right now, `--insecure` is broken.