### PR TITLE
Generate shell completions by calling tart.app executable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,6 +52,6 @@ brews:
     install: |
       libexec.install Dir["*"]
       bin.write_exec_script "#{libexec}/tart.app/Contents/MacOS/tart"
-      generate_completions_from_executable(bin/"tart", "--generate-completion-script")
+      generate_completions_from_executable(libexec/"tart.app/Contents/MacOS/tart", "--generate-completion-script")
     custom_block: |
       depends_on :macos => :ventura


### PR DESCRIPTION
At the point which homebrew generates the completions the exec script has not been made executable yet, so we can't rely on that.
