### PR TITLE
tart stop: throw RuntimeError.VMNotRunning consistently and use enumeration instead of strings

### DIFF
--- a/Sources/tart/Commands/Clone.swift
+++ b/Sources/tart/Commands/Clone.swift
@@ -63,7 +63,7 @@ struct Clone: AsyncParsableCommand {
       try lock.lock()
 
       let generateMAC = try localStorage.hasVMsWithMACAddress(macAddress: sourceVM.macAddress())
-        && sourceVM.state() != "suspended"
+        && sourceVM.state() != .Suspended
       try sourceVM.clone(to: tmpVMDir, generateMAC: generateMAC)
 
       try localStorage.move(newName, from: tmpVMDir)

--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -26,8 +26,7 @@ struct Get: AsyncParsableCommand {
     let vmConfig = try VMConfig(fromURL: vmDir.configURL)
     let memorySizeInMb = vmConfig.memorySize / 1024 / 1024
 
-    let info = VMInfo(OS: vmConfig.os, CPU: vmConfig.cpuCount, Memory: memorySizeInMb, Disk: try vmDir.sizeGB(), Size: String(format: "%.3f", Float(try vmDir.allocatedSizeBytes()) / 1000 / 1000 / 1000),
-                      Display: vmConfig.display.description, Running: try vmDir.running(), State: try vmDir.state())
+    let info = VMInfo(OS: vmConfig.os, CPU: vmConfig.cpuCount, Memory: memorySizeInMb, Disk: try vmDir.sizeGB(), Size: String(format: "%.3f", Float(try vmDir.allocatedSizeBytes()) / 1000 / 1000 / 1000), Display: vmConfig.display.description, Running: try vmDir.running(), State: try vmDir.state().rawValue)
     print(format.renderSingle(info))
   }
 }

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -38,13 +38,13 @@ struct List: AsyncParsableCommand {
 
     if source == nil || source == "local" {
       infos += sortedInfos(try VMStorageLocal().list().map { (name, vmDir) in
-        try VMInfo(Source: "local", Name: name, Disk: vmDir.sizeGB(), Size: vmDir.allocatedSizeGB(), Running: vmDir.running(), State: vmDir.state())
+        try VMInfo(Source: "local", Name: name, Disk: vmDir.sizeGB(), Size: vmDir.allocatedSizeGB(), Running: vmDir.running(), State: vmDir.state().rawValue)
       })
     }
 
     if source == nil || source == "oci" {
       infos += sortedInfos(try VMStorageOCI().list().map { (name, vmDir, _) in
-        try VMInfo(Source: "oci", Name: name, Disk: vmDir.sizeGB(), Size: vmDir.allocatedSizeGB(), Running: vmDir.running(), State: vmDir.state())
+        try VMInfo(Source: "oci", Name: name, Disk: vmDir.sizeGB(), Size: vmDir.allocatedSizeGB(), Running: vmDir.running(), State: vmDir.state().rawValue)
       })
     }
 

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -159,7 +159,7 @@ struct Run: AsyncParsableCommand {
 
     let localStorage = VMStorageLocal()
     let vmDir = try localStorage.open(name)
-    if try vmDir.state() == "suspended" {
+    if try vmDir.state() == .Suspended {
       suspendable = true
     }
 
@@ -182,7 +182,7 @@ struct Run: AsyncParsableCommand {
     let vmDir = try localStorage.open(name)
 
     let storageLock = try FileLock(lockURL: Config().tartHomeDir)
-    if try vmDir.state() == "suspended" {
+    if try vmDir.state() == .Suspended {
       try storageLock.lock() // lock before checking
       let needToGenerateNewMac = try localStorage.list().contains {
         // check if there is a running VM with the same MAC but different name

--- a/Sources/tart/Commands/Stop.swift
+++ b/Sources/tart/Commands/Stop.swift
@@ -15,11 +15,11 @@ struct Stop: AsyncParsableCommand {
   func run() async throws {
     let vmDir = try VMStorageLocal().open(name)
     switch try vmDir.state() {
-    case "suspended":
+    case .Suspended:
       try stopSuspended(vmDir)
-    case "running":
+    case .Running:
       try await stopRunning(vmDir)
-    default:
+    case .Stopped:
       return
     }
   }

--- a/Sources/tart/Commands/Stop.swift
+++ b/Sources/tart/Commands/Stop.swift
@@ -20,7 +20,7 @@ struct Stop: AsyncParsableCommand {
     case .Running:
       try await stopRunning(vmDir)
     case .Stopped:
-      return
+      throw RuntimeError.VMNotRunning(name)
     }
   }
 

--- a/Sources/tart/VMDirectory.swift
+++ b/Sources/tart/VMDirectory.swift
@@ -3,6 +3,12 @@ import Virtualization
 import CryptoKit
 
 struct VMDirectory: Prunable {
+  enum State: String {
+    case Running = "running"
+    case Suspended = "suspended"
+    case Stopped = "stopped"
+  }
+
   var baseURL: URL
 
   var configURL: URL {
@@ -47,13 +53,13 @@ struct VMDirectory: Prunable {
     return try lock.pid() != 0
   }
 
-  func state() throws -> String {
+  func state() throws -> State {
     if try running() {
-      return "running"
+      return State.Running
     } else if FileManager.default.fileExists(atPath: stateURL.path) {
-      return "suspended"
+      return State.Suspended
     } else {
-      return "stopped"
+      return State.Stopped
     }
   }
 


### PR DESCRIPTION
https://github.com/cirruslabs/tart/commit/202a6264b1c3413abd8da4aa5df2a11025d0af1c ensures that the `tart stop` behavior introduced in https://github.com/cirruslabs/tart/pull/321 still works.

https://github.com/cirruslabs/tart/commit/ce0ac404da1168c7266a4697a2c10acfe42f7fbe resolves https://github.com/cirruslabs/tart/issues/782.