### PR TITLE
Introduce `--random-mac` and `--random-serial` flags for `tart set`

### DIFF
--- a/Sources/tart/Commands/Set.swift
+++ b/Sources/tart/Commands/Set.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Foundation
+import Virtualization
 
 struct Set: AsyncParsableCommand {
   static var configuration = CommandConfiguration(commandName: "set", abstract: "Modify VM's configuration")
@@ -15,6 +16,12 @@ struct Set: AsyncParsableCommand {
 
   @Option(help: "VM display resolution in a format of <width>x<height>. For example, 1200x800")
   var display: VMDisplayConfig?
+
+  @Flag(help: ArgumentHelp("Generate a new random MAC address for the VM."))
+  var randomMAC: Bool = false
+
+  @Flag(help: ArgumentHelp("Generate a new random serial number for the macOS VM."))
+  var randomSerial: Bool = false
 
   @Option(help: ArgumentHelp("Resize the VMs disk to the specified size in GB (note that the disk size can only be increased to avoid losing data)",
                              discussion: """
@@ -49,6 +56,15 @@ struct Set: AsyncParsableCommand {
       if (display.height > 0) {
         vmConfig.display.height = display.height
       }
+    }
+
+    if randomMAC {
+      vmConfig.macAddress = VZMACAddress.randomLocallyAdministered()
+    }
+
+    if randomSerial {
+      let oldPlatform = vmConfig.platform as! Darwin
+      vmConfig.platform = Darwin(ecid: VZMacMachineIdentifier(), hardwareModel: oldPlatform.hardwareModel)
     }
 
     try vmConfig.save(toURL: vmDir.configURL)

--- a/Sources/tart/Commands/Set.swift
+++ b/Sources/tart/Commands/Set.swift
@@ -20,7 +20,9 @@ struct Set: AsyncParsableCommand {
   @Flag(help: ArgumentHelp("Generate a new random MAC address for the VM."))
   var randomMAC: Bool = false
 
-  @Flag(help: ArgumentHelp("Generate a new random serial number for the macOS VM."))
+  #if arch(arm64)
+    @Flag(help: ArgumentHelp("Generate a new random serial number for the macOS VM."))
+  #endif
   var randomSerial: Bool = false
 
   @Option(help: ArgumentHelp("Resize the VMs disk to the specified size in GB (note that the disk size can only be increased to avoid losing data)",
@@ -62,10 +64,12 @@ struct Set: AsyncParsableCommand {
       vmConfig.macAddress = VZMACAddress.randomLocallyAdministered()
     }
 
-    if randomSerial {
-      let oldPlatform = vmConfig.platform as! Darwin
-      vmConfig.platform = Darwin(ecid: VZMacMachineIdentifier(), hardwareModel: oldPlatform.hardwareModel)
-    }
+    #if arch(arm64)
+      if randomSerial {
+        let oldPlatform = vmConfig.platform as! Darwin
+        vmConfig.platform = Darwin(ecid: VZMacMachineIdentifier(), hardwareModel: oldPlatform.hardwareModel)
+      }
+    #endif
 
     try vmConfig.save(toURL: vmDir.configURL)
 


### PR DESCRIPTION
To generate new MAC address and/or serial number for a given VM.