### PR TITLE
integration-tests: downgrade "requests" package to 2.31.0

### DIFF
--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -1,6 +1,6 @@
 pytest
 testcontainers
-requests
+requests == 2.31.0 # work around https://github.com/psf/requests/issues/6707
 bitmath
 pytest-dependency
 paramiko


### PR DESCRIPTION
To fix the build failing.

See https://github.com/psf/requests/issues/6707 for more details.