### PR TITLE
Hook SIGUSR2 to requestStop

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -359,6 +359,18 @@ struct Run: AsyncParsableCommand {
     }
     sigusr1Src.activate()
 
+    // Gracefull shutdown support. For macOS this brings up a dialog,
+    // asking the user if they are sure they want to shut down.
+    signal(SIGUSR2, SIG_IGN)
+    let sigusr2Src = DispatchSource.makeSignalSource(signal: SIGUSR2)
+    sigusr2Src.setEventHandler {
+      Task {
+        print("Requesting guest OS to stop...")
+        try vm!.virtualMachine.requestStop()
+      }
+    }
+    sigusr2Src.activate()
+
     let useVNCWithoutGraphics = (vnc || vncExperimental) && !graphics
     if noGraphics || useVNCWithoutGraphics {
       // enter the main even loop, without bringing up any UI,


### PR DESCRIPTION
For macOS this brings up a dialog, asking the user if they are sure they want to shut down, which makes this less useful for automated graceful shutdowns, but it may behave better on Linux, and there might be ways to instruct macOS to not ask the user, so it's still a nice feature, and aligns with the SIGUSR1 for suspend, and SIGINT for non-graceful shutdown.