### PR TITLE
tart pull: choose across multiple VM images to deduplicate against

### DIFF
--- a/Sources/tart/OCI/Manifest.swift
+++ b/Sources/tart/OCI/Manifest.swift
@@ -78,7 +78,7 @@ struct OCIManifestConfig: Codable, Equatable {
   var digest: String
 }
 
-struct OCIManifestLayer: Codable, Equatable {
+struct OCIManifestLayer: Codable, Equatable, Hashable {
   var mediaType: String
   var size: Int
   var digest: String
@@ -112,6 +112,14 @@ struct OCIManifestLayer: Codable, Equatable {
 
   func uncompressedContentDigest() -> String? {
     annotations?[uncompressedContentDigestAnnotation]
+  }
+
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    return lhs.digest == rhs.digest
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(digest)
   }
 }
 

--- a/Sources/tart/VMDirectory+OCI.swift
+++ b/Sources/tart/VMDirectory+OCI.swift
@@ -79,6 +79,9 @@ extension VMDirectory {
       nvram.write(data)
     }
     try nvram.close()
+
+    // Serialize VM's manifest to enable better de-duplication on subsequent "tart pull"'s
+    try manifest.toJSON().write(to: manifestURL)
   }
 
   func pushToRegistry(registry: Registry, references: [String], chunkSizeMb: Int, diskFormat: String) async throws -> RemoteName {

--- a/Sources/tart/VMDirectory.swift
+++ b/Sources/tart/VMDirectory.swift
@@ -23,6 +23,9 @@ struct VMDirectory: Prunable {
   var stateURL: URL {
     baseURL.appendingPathComponent("state.vzvmsave")
   }
+  var manifestURL: URL {
+    baseURL.appendingPathComponent("manifest.json")
+  }
 
   var explicitlyPulledMark: URL {
     baseURL.appendingPathComponent(".explicitly-pulled")


### PR DESCRIPTION
This is accomplished by saving the OCI VM image manifests on "tart pull" in "manifest.json" file and then using them on successive "tart pull"'s to find the best candidate that results in the most de-duplication, measured in bytes.