### PR TITLE
--no-audio: only disable the source and sink

### DIFF
--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -312,15 +312,18 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     configuration.graphicsDevices = [vmConfig.platform.graphicsDevice(vmConfig: vmConfig)]
 
     // Audio
+    let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
+
+    let inputAudioStreamConfiguration = VZVirtioSoundDeviceInputStreamConfiguration()
+    let outputAudioStreamConfiguration = VZVirtioSoundDeviceOutputStreamConfiguration()
+
     if audio && !suspendable {
-      let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
-      let inputAudioStreamConfiguration = VZVirtioSoundDeviceInputStreamConfiguration()
       inputAudioStreamConfiguration.source = VZHostAudioInputStreamSource()
-      let outputAudioStreamConfiguration = VZVirtioSoundDeviceOutputStreamConfiguration()
       outputAudioStreamConfiguration.sink = VZHostAudioOutputStreamSink()
-      soundDeviceConfiguration.streams = [inputAudioStreamConfiguration, outputAudioStreamConfiguration]
-      configuration.audioDevices = [soundDeviceConfiguration]
     }
+
+    soundDeviceConfiguration.streams = [inputAudioStreamConfiguration, outputAudioStreamConfiguration]
+    configuration.audioDevices = [soundDeviceConfiguration]
 
     // Keyboard and mouse
     configuration.keyboards = vmConfig.platform.keyboards()


### PR DESCRIPTION
To prevent crashes in the guest when playing or recording audio and (1) no permission is given or (2) `--no-audio` is used.

Suspend seems to work fine.