### PR TITLE
APFS reuse UX/DX improvements

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6d48639bc0ea02002de0b4f38fe3fce0ddc9d174f2e56180c2ffcbedb7391ef8",
+  "originHash" : "2c514a4a1d7e106713db744bee89edb40d75da63e6611990ec2f4b0da53c0455",
   "pins" : [
     {
       "identity" : "antlr4",
@@ -116,6 +116,15 @@
       "state" : {
         "revision" : "a91be36de6803ebe48f678699dfd0694c2200d2f",
         "version" : "1.8.0"
+      }
+    },
+    {
+      "identity" : "swift-xattr",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jozefizso/swift-xattr",
+      "state" : {
+        "revision" : "f8605af7b3290dbb235fb182ec6e9035d0c8c3ac",
+        "version" : "3.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
     .package(url: "https://github.com/orchetect/SwiftRadix", from: "1.3.1"),
     .package(url: "https://github.com/groue/Semaphore", from: "0.0.8"),
     .package(url: "https://github.com/fumoboy007/swift-retry", from: "0.2.3"),
+    .package(url: "https://github.com/jozefizso/swift-xattr", from: "3.0.0"),
   ],
   targets: [
     .executableTarget(name: "tart", dependencies: [
@@ -40,6 +41,7 @@ let package = Package(
       .product(name: "SwiftRadix", package: "SwiftRadix"),
       .product(name: "Semaphore", package: "Semaphore"),
       .product(name: "DMRetry", package: "swift-retry"),
+      .product(name: "XAttr", package: "swift-xattr"),
     ], exclude: [
       "OCI/Reference/Makefile",
       "OCI/Reference/Reference.g4",

--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -7,6 +7,7 @@ fileprivate struct VMInfo: Encodable {
   let Name: String
   let Disk: Int
   let Size: Int
+  let SizeOnDisk: Int
   let Running: Bool
   let State: String
 }
@@ -38,13 +39,13 @@ struct List: AsyncParsableCommand {
 
     if source == nil || source == "local" {
       infos += sortedInfos(try VMStorageLocal().list().map { (name, vmDir) in
-        try VMInfo(Source: "local", Name: name, Disk: vmDir.sizeGB(), Size: vmDir.allocatedSizeGB(), Running: vmDir.running(), State: vmDir.state().rawValue)
+        try VMInfo(Source: "local", Name: name, Disk: vmDir.sizeGB(), Size: vmDir.allocatedSizeGB(), SizeOnDisk: vmDir.allocatedSizeGB() - vmDir.deduplicatedSizeGB(), Running: vmDir.running(), State: vmDir.state().rawValue)
       })
     }
 
     if source == nil || source == "oci" {
       infos += sortedInfos(try VMStorageOCI().list().map { (name, vmDir, _) in
-        try VMInfo(Source: "OCI", Name: name, Disk: vmDir.sizeGB(), Size: vmDir.allocatedSizeGB(), Running: vmDir.running(), State: vmDir.state().rawValue)
+        try VMInfo(Source: "OCI", Name: name, Disk: vmDir.sizeGB(), Size: vmDir.allocatedSizeGB(), SizeOnDisk: vmDir.allocatedSizeGB() - vmDir.deduplicatedSizeGB(), Running: vmDir.running(), State: vmDir.state().rawValue)
       })
     }
 

--- a/Sources/tart/URL+Prunable.swift
+++ b/Sources/tart/URL+Prunable.swift
@@ -25,16 +25,18 @@ extension URL: Prunable {
   }
 
   func setDeduplicatedBytes(_ size: UInt64) {
-    var intVal = size
-    let data = Data(bytes: &intVal, count: MemoryLayout.size(ofValue: intVal))
-    try! self.setExtendedAttribute(name: "user.deduplicatedBytes", value: data)
+    let data = "\(size)".data(using: .utf8)!
+    try! self.setExtendedAttribute(name: "run.tart.deduplicated-bytes", value: data)
   }
 
   func deduplicatedBytes() -> UInt64 {
-    let data = try? self.extendedAttributeValue(forName: "user.deduplicatedBytes")
-    if data == nil {
+    let data = try? self.extendedAttributeValue(forName: "run.tart.deduplicated-bytes")
+    guard let data else {
       return 0
     }
-    return data!.withUnsafeBytes { $0.load(as: UInt64.self) }
+    if let strValue = String(data: data, encoding: .utf8) {
+      return UInt64(strValue) ?? 0
+    }
+    return 0
   }
 }

--- a/Sources/tart/URL+Prunable.swift
+++ b/Sources/tart/URL+Prunable.swift
@@ -30,8 +30,7 @@ extension URL: Prunable {
   }
 
   func deduplicatedBytes() -> UInt64 {
-    let data = try? self.extendedAttributeValue(forName: "run.tart.deduplicated-bytes")
-    guard let data else {
+    guard let data = try? self.extendedAttributeValue(forName: "run.tart.deduplicated-bytes") else {
       return 0
     }
     if let strValue = String(data: data, encoding: .utf8) {

--- a/Sources/tart/URL+Prunable.swift
+++ b/Sources/tart/URL+Prunable.swift
@@ -11,13 +11,17 @@ extension URL: Prunable {
   }
 
   func allocatedSizeBytes() throws -> Int {
+    try resourceValues(forKeys: [.totalFileAllocatedSizeKey]).totalFileAllocatedSize!
+  }
+
+  func deduplicatedSizeBytes() throws -> Int {
     let values = try resourceValues(forKeys: [.totalFileAllocatedSizeKey, .mayShareFileContentKey])
     // make sure the file's origin file is there and duplication works
     var dedublicatedSize = 0
     if values.mayShareFileContent == true {
-      dedublicatedSize = Int(deduplicatedBytes())
+      return Int(deduplicatedBytes())
     }
-    return values.totalFileAllocatedSize! - dedublicatedSize
+    return 0
   }
 
   func sizeBytes() throws -> Int {

--- a/Sources/tart/URL+Prunable.swift
+++ b/Sources/tart/URL+Prunable.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XAttr
 
 extension URL: Prunable {
   var url: URL {
@@ -10,10 +11,30 @@ extension URL: Prunable {
   }
 
   func allocatedSizeBytes() throws -> Int {
-    try resourceValues(forKeys: [.totalFileAllocatedSizeKey]).totalFileAllocatedSize!
+    let values = try resourceValues(forKeys: [.totalFileAllocatedSizeKey, .mayShareFileContentKey])
+    // make sure the file's origin file is there and duplication works
+    var dedublicatedSize = 0
+    if values.mayShareFileContent == true {
+      dedublicatedSize = Int(deduplicatedBytes())
+    }
+    return values.totalFileAllocatedSize! - dedublicatedSize
   }
 
   func sizeBytes() throws -> Int {
     try resourceValues(forKeys: [.totalFileSizeKey]).totalFileSize!
+  }
+
+  func setDeduplicatedBytes(_ size: UInt64) {
+    var intVal = size
+    let data = Data(bytes: &intVal, count: MemoryLayout.size(ofValue: intVal))
+    try! self.setExtendedAttribute(name: "user.deduplicatedBytes", value: data)
+  }
+
+  func deduplicatedBytes() -> UInt64 {
+    let data = try? self.extendedAttributeValue(forName: "user.deduplicatedBytes")
+    if data == nil {
+      return 0
+    }
+    return data!.withUnsafeBytes { $0.load(as: UInt64.self) }
   }
 }

--- a/Sources/tart/VMDirectory+OCI.swift
+++ b/Sources/tart/VMDirectory+OCI.swift
@@ -59,6 +59,11 @@ extension VMDirectory {
       throw RuntimeError.PullFailed("failed to decompress disk: \(error.localizedDescription)")
     }
 
+    if let llc = localLayerCache {
+      // set custom attribute to remember deduplicated bytes
+      diskURL.setDeduplicatedBytes(llc.deduplicatedBytes)
+    }
+
     // Pull VM's NVRAM file layer and store it in an NVRAM file
     defaultLogger.appendNewLine("pulling NVRAM...")
 

--- a/Sources/tart/VMDirectory.swift
+++ b/Sources/tart/VMDirectory.swift
@@ -182,6 +182,14 @@ struct VMDirectory: Prunable {
     try allocatedSizeBytes() / 1000 / 1000 / 1000
   }
 
+  func deduplicatedSizeBytes() throws -> Int {
+    try configURL.deduplicatedSizeBytes() + diskURL.deduplicatedSizeBytes() + nvramURL.deduplicatedSizeBytes()
+  }
+
+  func deduplicatedSizeGB() throws -> Int {
+    try deduplicatedSizeBytes() / 1000 / 1000 / 1000
+  }
+
   func sizeBytes() throws -> Int {
     try configURL.sizeBytes() + diskURL.sizeBytes() + nvramURL.sizeBytes()
   }


### PR DESCRIPTION
Improvement to the APFS deduplication logic which checks whether a disk image file `mayShareFileContent` with some other file, and then we put a custom attribute to track the deduplication since there is no way to get this information from APFS itself.

It's not 100% accurate but given that OCI cache is immutable the actual disk usage can only be lover than that.