### PR TITLE
Support setting root disk synchronization mode

### DIFF
--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -1,6 +1,5 @@
 import ArgumentParser
 import Foundation
-import Virtualization
 
 fileprivate struct VMInfo: Encodable {
   let OS: OS

--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Foundation
+import Virtualization
 
 fileprivate struct VMInfo: Encodable {
   let OS: OS
@@ -7,6 +8,7 @@ fileprivate struct VMInfo: Encodable {
   let Memory: UInt64
   let Disk: Int
   let Size: String
+  let Sync: String
   let Display: String
   let Running: Bool
   let State: String
@@ -26,7 +28,7 @@ struct Get: AsyncParsableCommand {
     let vmConfig = try VMConfig(fromURL: vmDir.configURL)
     let memorySizeInMb = vmConfig.memorySize / 1024 / 1024
 
-    let info = VMInfo(OS: vmConfig.os, CPU: vmConfig.cpuCount, Memory: memorySizeInMb, Disk: try vmDir.sizeGB(), Size: String(format: "%.3f", Float(try vmDir.allocatedSizeBytes()) / 1000 / 1000 / 1000), Display: vmConfig.display.description, Running: try vmDir.running(), State: try vmDir.state().rawValue)
+    let info = VMInfo(OS: vmConfig.os, CPU: vmConfig.cpuCount, Memory: memorySizeInMb, Disk: try vmDir.sizeGB(), Size: String(format: "%.3f", Float(try vmDir.allocatedSizeBytes()) / 1000 / 1000 / 1000), Sync: vmConfig.sync.description, Display: vmConfig.display.description, Running: try vmDir.running(), State: try vmDir.state().rawValue)
     print(format.renderSingle(info))
   }
 }

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -350,7 +350,7 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     // Storage
     let attachment: VZDiskImageStorageDeviceAttachment = vmConfig.os == .linux ?
       // Use "cached" caching mode for virtio drive to prevent fs corruption on linux
-      try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false, cachingMode: .cached, synchronizationMode: .full) :
+      try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false, cachingMode: .cached, synchronizationMode: vmConfig.sync) :
       try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false)
 
     var device: VZStorageDeviceConfiguration

--- a/Sources/tart/VMConfig.swift
+++ b/Sources/tart/VMConfig.swift
@@ -24,6 +24,7 @@ enum CodingKeys: String, CodingKey {
   case memorySize
   case macAddress
   case display
+  case sync
 
   // macOS-specific keys
   case ecid
@@ -41,6 +42,34 @@ extension VMDisplayConfig: CustomStringConvertible {
   }
 }
 
+extension VZDiskImageSynchronizationMode : LosslessStringConvertible {
+  public init?(_ description: String) {
+    switch description {
+    case "none":
+      self = .none
+    case "fsync":
+      self = .fsync
+    case "full":
+      self = .full
+    default:
+      return nil
+    }
+  }
+
+  public var description: String {
+    switch self {
+    case .none:
+      return "none"
+    case .fsync:
+      return "fsync"
+    case .full:
+      return "full"
+    @unknown default:
+      return "unknown"
+    }
+  }
+}
+
 struct VMConfig: Codable {
   var version: Int = 1
   var os: OS
@@ -52,6 +81,7 @@ struct VMConfig: Codable {
   private(set) var memorySize: UInt64
   var macAddress: VZMACAddress
   var display: VMDisplayConfig = VMDisplayConfig()
+  var sync: VZDiskImageSynchronizationMode = .full
 
   init(
     platform: Platform,
@@ -121,6 +151,8 @@ struct VMConfig: Codable {
     self.macAddress = macAddress
 
     display = try container.decodeIfPresent(VMDisplayConfig.self, forKey: .display) ?? VMDisplayConfig()
+
+    sync = VZDiskImageSynchronizationMode(try container.decodeIfPresent(String.self, forKey: .sync) ?? "full") ?? .full
   }
 
   func encode(to encoder: Encoder) throws {
@@ -136,6 +168,7 @@ struct VMConfig: Codable {
     try container.encode(memorySize, forKey: .memorySize)
     try container.encode(macAddress.string, forKey: .macAddress)
     try container.encode(display, forKey: .display)
+    try container.encode(sync.description, forKey: .sync)
   }
 
   mutating func setCPU(cpuCount: Int) throws {


### PR DESCRIPTION
﻿﻿Following on from https://github.com/cirruslabs/tart/pull/872, also support setting VZDiskImageSynchronizationMode for /.

This is useful because it significantly improves write performance in situations where the increased potential for data loss doesn't matter.