### PR TITLE
tart run: replace --sync with --root-disk-opts

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -12,7 +12,7 @@ var vm: VM?
 struct IPNotFound: Error {
 }
 
-extension VZDiskImageSynchronizationMode : LosslessStringConvertible {
+extension VZDiskImageSynchronizationMode {
   public init?(_ description: String) {
     switch description {
     case "none":
@@ -23,19 +23,6 @@ extension VZDiskImageSynchronizationMode : LosslessStringConvertible {
       self = .full
     default:
       return nil
-    }
-  }
-
-  public var description: String {
-    switch self {
-    case .none:
-      return "none"
-    case .fsync:
-      return "fsync"
-    case .full:
-      return "full"
-    @unknown default:
-      return "unknown"
     }
   }
 }

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -354,7 +354,7 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     let attachment: VZDiskImageStorageDeviceAttachment = vmConfig.os == .linux ?
       // Use "cached" caching mode for virtio drive to prevent fs corruption on linux
       try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false, cachingMode: .cached, synchronizationMode: sync) :
-      try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false)
+      try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false, cachingMode: .automatic, synchronizationMode: sync)
 
     var device: VZStorageDeviceConfiguration
     if #available(macOS 14, *), vmConfig.os == .linux {


### PR DESCRIPTION
See https://github.com/cirruslabs/tart/pull/875#issuecomment-2265359773.

Also added support for passing the synchronization mode to macOS root disk in https://github.com/cirruslabs/tart/pull/879/commits/2338e0beb0fa2a03de462dc1e7bf1958a8728765.