### PR TITLE
Completely disable audio devices in case of `--no-audio`

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -70,7 +70,7 @@ struct Run: AsyncParsableCommand {
   @Flag(help: ArgumentHelp("Force open a UI window, even when VNC is enabled.", visibility: .private))
   var graphics: Bool = false
 
-  @Flag(help: "Disable audio pass-through to host.")
+  @Flag(help: "Do not configure audio device.")
   var noAudio: Bool = false
 
   @Flag(help: ArgumentHelp(

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -70,7 +70,7 @@ struct Run: AsyncParsableCommand {
   @Flag(help: ArgumentHelp("Force open a UI window, even when VNC is enabled.", visibility: .private))
   var graphics: Bool = false
 
-  @Flag(help: "Do not configure audio device.")
+  @Flag(help: "Disable audio pass-through to host.")
   var noAudio: Bool = false
 
   @Flag(help: ArgumentHelp(

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -315,18 +315,18 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     configuration.graphicsDevices = [vmConfig.platform.graphicsDevice(vmConfig: vmConfig)]
 
     // Audio
-    let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
-
-    let inputAudioStreamConfiguration = VZVirtioSoundDeviceInputStreamConfiguration()
-    let outputAudioStreamConfiguration = VZVirtioSoundDeviceOutputStreamConfiguration()
-
     if audio && !suspendable {
+      let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
+
+      let inputAudioStreamConfiguration = VZVirtioSoundDeviceInputStreamConfiguration()
+      let outputAudioStreamConfiguration = VZVirtioSoundDeviceOutputStreamConfiguration()
+
       inputAudioStreamConfiguration.source = VZHostAudioInputStreamSource()
       outputAudioStreamConfiguration.sink = VZHostAudioOutputStreamSink()
-    }
 
-    soundDeviceConfiguration.streams = [inputAudioStreamConfiguration, outputAudioStreamConfiguration]
-    configuration.audioDevices = [soundDeviceConfiguration]
+      soundDeviceConfiguration.streams = [inputAudioStreamConfiguration, outputAudioStreamConfiguration]
+      configuration.audioDevices = [soundDeviceConfiguration]
+    }
 
     // Keyboard and mouse
     if suspendable, let platformSuspendable = vmConfig.platform.self as? PlatformSuspendable {

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -315,9 +315,9 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     configuration.graphicsDevices = [vmConfig.platform.graphicsDevice(vmConfig: vmConfig)]
 
     // Audio
-    if audio && !suspendable {
-      let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
+    let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
 
+    if audio && !suspendable {
       let inputAudioStreamConfiguration = VZVirtioSoundDeviceInputStreamConfiguration()
       let outputAudioStreamConfiguration = VZVirtioSoundDeviceOutputStreamConfiguration()
 
@@ -325,8 +325,12 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
       outputAudioStreamConfiguration.sink = VZHostAudioOutputStreamSink()
 
       soundDeviceConfiguration.streams = [inputAudioStreamConfiguration, outputAudioStreamConfiguration]
-      configuration.audioDevices = [soundDeviceConfiguration]
+    } else {
+      // just a null speaker
+      soundDeviceConfiguration.streams = [VZVirtioSoundDeviceOutputStreamConfiguration()]
     }
+
+    configuration.audioDevices = [soundDeviceConfiguration]
 
     // Keyboard and mouse
     if suspendable, let platformSuspendable = vmConfig.platform.self as? PlatformSuspendable {


### PR DESCRIPTION
With the current behaviour VMs do have audio devices but they don't pass-through signal to host which can lead to issues like https://github.com/actions/runner-images/issues/9330 . 

With this change there will be just no audio at all but commands like `say "hello"` work fine. So people don't need to apply the workaround for the permission dialog at all.