### PR TITLE
tart delete: return human-friendly error when local VM doesn't exist

### DIFF
--- a/Sources/tart/PIDLock.swift
+++ b/Sources/tart/PIDLock.swift
@@ -11,7 +11,7 @@ class PIDLock {
     if fd == -1 {
       let details = Errno(rawValue: CInt(errno))
 
-      throw RuntimeError.PIDLockFailed("failed to open lock file \(url): \(details)")
+      throw RuntimeError.PIDLockMissing("failed to open lock file \(url): \(details)")
     }
   }
 

--- a/Sources/tart/VMStorageHelper.swift
+++ b/Sources/tart/VMStorageHelper.swift
@@ -24,6 +24,8 @@ class VMStorageHelper {
   private static func missingVMWrap<R: Any>(_ name: String, closure: () throws -> R) throws -> R {
     do {
       return try closure()
+    } catch RuntimeError.PIDLockMissing {
+      throw RuntimeError.VMDoesNotExist(name: name)
     } catch {
       if error.isFileNotFound() {
         throw RuntimeError.VMDoesNotExist(name: name)
@@ -59,6 +61,7 @@ enum RuntimeError : Error {
   case InvalidDiskSize(_ message: String)
   case FailedToUpdateAccessDate(_ message: String)
   case PIDLockFailed(_ message: String)
+  case PIDLockMissing(_ message: String)
   case FailedToParseRemoteName(_ message: String)
   case VMTerminationFailed(_ message: String)
   case ImproperlyFormattedHost(_ host: String, _ hint: String)
@@ -104,6 +107,8 @@ extension RuntimeError : CustomStringConvertible {
     case .FailedToUpdateAccessDate(let message):
       return message
     case .PIDLockFailed(let message):
+      return message
+    case .PIDLockMissing(let message):
       return message
     case .FailedToParseRemoteName(let cause):
       return "failed to parse remote name: \(cause)"


### PR DESCRIPTION
Current behavior:

```
% tart delete non-existent ; echo $?
failed to open lock file file:///Users/edi/.tart/vms/non-existent/config.json: No such file or directory
1
```

With this PR:

```
% tart delete non-existent ; echo $?
the specified VM "non-existent" does not exist
2
```

Related to https://github.com/cirruslabs/packer-plugin-tart/issues/168.