### PR TITLE
Make `ARPCache` to respect cancellation

### DIFF
--- a/Sources/tart/Commands/IP.swift
+++ b/Sources/tart/Commands/IP.swift
@@ -57,7 +57,7 @@ struct IP: AsyncParsableCommand {
     repeat {
       switch resolutionStrategy {
       case .arp:
-        if let ip = try ARPCache().ResolveMACAddress(macAddress: vmMACAddress) {
+        if let ip = try await ARPCache().ResolveMACAddress(macAddress: vmMACAddress) {
           return ip
         }
       case .dhcp:


### PR DESCRIPTION
By manually handling `waitUntilExit`

Tested by using `/bin/sleep 120` instead of `/usr/sbin/arp -an`.