### PR TITLE
Prevent pipe deadlock when spawning a Process()

### DIFF
--- a/Sources/tart/Credentials/DockerConfigCredentialsProvider.swift
+++ b/Sources/tart/Credentials/DockerConfigCredentialsProvider.swift
@@ -39,9 +39,10 @@ class DockerConfigCredentialsProvider: CredentialsProvider {
     inPipe.fileHandleForWriting.write("\(host)\n".data(using: .utf8)!)
     inPipe.fileHandleForWriting.closeFile()
 
+    let outputData = try outPipe.fileHandleForReading.readToEnd()
+
     process.waitUntilExit()
 
-    let outputData = try outPipe.fileHandleForReading.readToEnd()
     if !(process.terminationReason == .exit && process.terminationStatus == 0) {
       if let outputData = outputData {
         print(String(decoding: outputData, as: UTF8.self))

--- a/Sources/tart/MACAddressResolver/ARPCache.swift
+++ b/Sources/tart/MACAddressResolver/ARPCache.swift
@@ -52,16 +52,17 @@ struct ARPCache {
     process.standardInput = FileHandle.nullDevice
 
     try process.run()
+
+    guard let arpCommandOutput = try pipe.fileHandleForReading.readToEnd() else {
+      throw ARPCommandYieldedInvalidOutputError(explanation: "empty output")
+    }
+
     process.waitUntilExit()
 
     if !(process.terminationReason == .exit && process.terminationStatus == 0) {
       throw ARPCommandFailedError(
         terminationReason: process.terminationReason,
         terminationStatus: process.terminationStatus)
-    }
-
-    guard let arpCommandOutput = try pipe.fileHandleForReading.readToEnd() else {
-      throw ARPCommandYieldedInvalidOutputError(explanation: "empty output")
     }
 
     self.arpCommandOutput = arpCommandOutput


### PR DESCRIPTION
`arp -an` output can be large enough not to fit in pipe's internal buffer, causing a deadlock: `arp` can't write to the pipe anymore, but we don't help it by reading from the other end.

This also addresses other places with a similar potentially deadlocking pattern.