### PR TITLE
Update access time on `pull`

### DIFF
--- a/Sources/tart/Commands/Pull.swift
+++ b/Sources/tart/Commands/Pull.swift
@@ -47,5 +47,8 @@ struct Pull: AsyncParsableCommand {
     defaultLogger.appendNewLine("pulling \(remoteName)...")
 
     try await VMStorageOCI().pull(remoteName, registry: registry, concurrency: concurrency, deduplicate: deduplicate)
+
+    // to explicitly set the image as being accessed so it won't get pruned immediately
+    _ = try VMStorageOCI().open(remoteName)
   }
 }


### PR DESCRIPTION
To make sure we won't prune then immediately after. Useful for when scenarios similar to Cirrus CLI when we make sure that several images are up-to-date before every request for task execution.