### PR TITLE
Linux VMs: do not use NVMe storage device

### DIFF
--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -365,13 +365,7 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
       try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false, cachingMode: .cached, synchronizationMode: sync) :
       try VZDiskImageStorageDeviceAttachment(url: diskURL, readOnly: false, cachingMode: .automatic, synchronizationMode: sync)
 
-    var device: VZStorageDeviceConfiguration
-    if #available(macOS 14, *), vmConfig.os == .linux {
-      device = VZNVMExpressControllerDeviceConfiguration(attachment: attachment)
-    } else {
-      device = VZVirtioBlockDeviceConfiguration(attachment: attachment)
-    }
-    var devices: [VZStorageDeviceConfiguration] = [device]
+    var devices: [VZStorageDeviceConfiguration] = [VZVirtioBlockDeviceConfiguration(attachment: attachment)]
     devices.append(contentsOf: additionalStorageDevices)
     configuration.storageDevices = devices
 


### PR DESCRIPTION
This was introduced in https://github.com/cirruslabs/tart/pull/675 to allegedly fix filesystem corruption on Linux VMs.

However, it's likely that simply using the `.cached` mode is more than enough, see these two comments:

* https://github.com/cirruslabs/tart/pull/675#issuecomment-1835702331
* https://github.com/cirruslabs/tart/pull/675#issuecomment-1882601168

Resolves https://github.com/cirruslabs/tart/issues/930.