### PR TITLE
Info.plist: do not use LSBackgroundOnly

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -10,8 +10,6 @@
 	<string>org.cirruslabs.tart</string>
 	<key>CFBundleExecutable</key>
 	<string>tart</string>
-	<key>LSBackgroundOnly</key>
-	<string>1</string>
 	<key>CFBundleIconFiles</key>
 	<array>
 		<string>AppIcon.png</string>


### PR DESCRIPTION
This was introduced in https://github.com/cirruslabs/tart/pull/746, but I've tested this change with `tart create --from-ipsw=latest <VM>`, and no icon in Dock was shown.

Resolves https://github.com/cirruslabs/tart/issues/928.