### PR TITLE
tart pull: open the VM directory after pulling under a lock

### DIFF
--- a/Sources/tart/Commands/Pull.swift
+++ b/Sources/tart/Commands/Pull.swift
@@ -47,8 +47,5 @@ struct Pull: AsyncParsableCommand {
     defaultLogger.appendNewLine("pulling \(remoteName)...")
 
     try await VMStorageOCI().pull(remoteName, registry: registry, concurrency: concurrency, deduplicate: deduplicate)
-
-    // to explicitly set the image as being accessed so it won't get pruned immediately
-    _ = try VMStorageOCI().open(remoteName)
   }
 }

--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -239,6 +239,9 @@ class VMStorageOCI: PrunableStorage {
       // are excluded from garbage collection
       VMDirectory(baseURL: vmURL(name)).markExplicitlyPulled()
     }
+
+    // to explicitly set the image as being accessed so it won't get pruned immediately
+    _ = try VMStorageOCI().open(name)
   }
 
   func linked(from: RemoteName, to: RemoteName) -> Bool {


### PR DESCRIPTION
Otherwise it's possible for the VM to be garbage collected by some other Tart process.

Possibly related to `PERSISTENT-WORKERS-44`.