### PR TITLE
tart run: set "prohibited" activation policy when --no-graphics is set

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -472,8 +472,10 @@ struct Run: AsyncParsableCommand {
 
     let useVNCWithoutGraphics = (vnc || vncExperimental) && !graphics
     if noGraphics || useVNCWithoutGraphics {
-      // enter the main even loop, without bringing up any UI,
-      // and just wait for the VM to exit.
+      // Enter the main event loop without bringing up any UI,
+      // waiting for the VM to exit.
+      NSApplication.shared.setActivationPolicy(.prohibited)
+
       NSApplication.shared.run()
     } else {
       runUI(suspendable, captureSystemKeys)


### PR DESCRIPTION
This is a missing piece from https://github.com/cirruslabs/tart/pull/935.

I should've been testing the presence of dock icon with `tart run --no-graphics` instead of `tart create --from-ipsw=latest`.

Unfortunately the dock icon is still shown for about 10ms even with `prohibited`, but that's the best we can do, according to https://stackoverflow.com/a/12981068/9316533:

>Workaround: Starting as normal app (step 1.) would solve this problem, but will cause another small one, **your app icon might appear for a moment in the dock at startup even if you would like to startup without any window shown**. (but we can deal with this, not owning the menubar was a bigger problem for us, so we chose this instead)