### PR TITLE
Set application category

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -10,6 +10,8 @@
 	<string>org.cirruslabs.tart</string>
 	<key>CFBundleExecutable</key>
 	<string>tart</string>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.developer-tools</string>
 	<key>CFBundleIconFiles</key>
 	<array>
 		<string>AppIcon.png</string>


### PR DESCRIPTION
Was looking into performance and was wondering about Game Mode on Sonoma.

This change is unrelated. Just found they have a category for tools like Tart.