### PR TITLE
tart pull: retry if we get URLError

### DIFF
--- a/Sources/tart/VMStorageOCI.swift
+++ b/Sources/tart/VMStorageOCI.swift
@@ -212,7 +212,7 @@ class VMStorageOCI: PrunableStorage {
 
           try await tmpVMDir.pullFromRegistry(registry: registry, manifest: manifest, concurrency: concurrency, localLayerCache: localLayerCache, deduplicate: deduplicate)
         } recoverFromFailure: { error in
-          if error is Retryable {
+          if error is URLError {
             print("Error: \(error.localizedDescription)")
             print("Attempting to re-try...")
 


### PR DESCRIPTION
No one is going to throw `Retryable` anyway.

This makes the logic similar to the `tart push` side of things:

https://github.com/cirruslabs/tart/blob/cd0f238a678bc534ea8a94b8dfd945feecc487b8/Sources/tart/OCI/Layerizer/DiskV2.swift#L37-L42

Resolves https://github.com/cirruslabs/tart/issues/944.