### PR TITLE
Add flag to allow automatically reconfigure display for linux VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ dist/
 
 # mkdocs-material
 site
+
+DerivedData
+.vscode

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -201,9 +201,6 @@ struct Run: AsyncParsableCommand {
   #endif
   var captureSystemKeys: Bool = false
 
-  @Flag(name: [.customLong("allows-reconfigure-display")], help: ArgumentHelp("Allow to reconfigure display when window is resized for linux VM"))
-  var automaticallyReconfiguresDisplay: Bool = false
-
   mutating func validate() throws {
     if vnc && vncExperimental {
       throw ValidationError("--vnc and --vnc-experimental are mutually exclusive")
@@ -481,7 +478,7 @@ struct Run: AsyncParsableCommand {
 
       NSApplication.shared.run()
     } else {
-      runUI(suspendable, captureSystemKeys, vm?.config.os == .darwin || automaticallyReconfiguresDisplay)
+      runUI(suspendable, captureSystemKeys, vm?.config.os == .darwin || vm?.config.automaticallyReconfiguresDisplay ?? false)
     }
   }
 

--- a/Sources/tart/Commands/Set.swift
+++ b/Sources/tart/Commands/Set.swift
@@ -17,6 +17,9 @@ struct Set: AsyncParsableCommand {
   @Option(help: "VM display resolution in a format of <width>x<height>. For example, 1200x800")
   var display: VMDisplayConfig?
 
+  @Flag(name: [.customLong("allows-reconfigure-display")], help: ArgumentHelp("Allow to reconfigure display when window is resized for linux VM"))
+  var automaticallyReconfiguresDisplay: Bool = false
+
   @Flag(help: ArgumentHelp("Generate a new random MAC address for the VM."))
   var randomMAC: Bool = false
 
@@ -73,6 +76,8 @@ struct Set: AsyncParsableCommand {
         vmConfig.platform = Darwin(ecid: VZMacMachineIdentifier(), hardwareModel: oldPlatform.hardwareModel)
       }
     #endif
+
+    vmConfig.automaticallyReconfiguresDisplay = automaticallyReconfiguresDisplay
 
     try vmConfig.save(toURL: vmDir.configURL)
 

--- a/Sources/tart/VMConfig.swift
+++ b/Sources/tart/VMConfig.swift
@@ -24,6 +24,7 @@ enum CodingKeys: String, CodingKey {
   case memorySize
   case macAddress
   case display
+  case automaticallyReconfiguresDisplay
 
   // macOS-specific keys
   case ecid
@@ -52,6 +53,7 @@ struct VMConfig: Codable {
   private(set) var memorySize: UInt64
   var macAddress: VZMACAddress
   var display: VMDisplayConfig = VMDisplayConfig()
+  var automaticallyReconfiguresDisplay: Bool = false
 
   init(
     platform: Platform,
@@ -121,6 +123,7 @@ struct VMConfig: Codable {
     self.macAddress = macAddress
 
     display = try container.decodeIfPresent(VMDisplayConfig.self, forKey: .display) ?? VMDisplayConfig()
+    automaticallyReconfiguresDisplay = try container.decodeIfPresent(Bool.self, forKey: .automaticallyReconfiguresDisplay) ?? false
   }
 
   func encode(to encoder: Encoder) throws {
@@ -136,6 +139,7 @@ struct VMConfig: Codable {
     try container.encode(memorySize, forKey: .memorySize)
     try container.encode(macAddress.string, forKey: .macAddress)
     try container.encode(display, forKey: .display)
+    try container.encode(automaticallyReconfiguresDisplay, forKey: .automaticallyReconfiguresDisplay)
   }
 
   mutating func setCPU(cpuCount: Int) throws {


### PR DESCRIPTION
By default when using tart to create linux VM with graphical desktop, the resizing of the window don't resize linux desktop and doesn't permit fullscreen.

This pull request add a flag --allows-reconfigure-display to run command permitting machineView.automaticallyReconfiguresDisplay = true