### PR TITLE
tart set: support --{,no-}display-auto-reconfigure

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -740,12 +740,12 @@ struct VMView: NSViewRepresentable {
 
     machineView.capturesSystemKeys = capturesSystemKeys
 
-    // Enable automatic display reconfiguration
-    // for guests that support it
+    // If not specified, enable automatic display
+    // reconfiguration for guests that support it
     //
     // This is disabled for Linux because of poor HiDPI
     // support, which manifests in fonts being too small
-    if #available(macOS 14.0, *), vm.config.os != .linux {
+    if #available(macOS 14.0, *), vm.config.displayAutoReconfigure ?? (vm.config.os != .linux) {
       machineView.automaticallyReconfiguresDisplay = true
     }
 

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -745,7 +745,7 @@ struct VMView: NSViewRepresentable {
     //
     // This is disabled for Linux because of poor HiDPI
     // support, which manifests in fonts being too small
-    if #available(macOS 14.0, *), vm.config.displayAutoReconfigure ?? (vm.config.os != .linux) {
+    if #available(macOS 14.0, *), vm.config.displayRefit ?? (vm.config.os != .linux) {
       machineView.automaticallyReconfiguresDisplay = true
     }
 

--- a/Sources/tart/Commands/Set.swift
+++ b/Sources/tart/Commands/Set.swift
@@ -18,7 +18,7 @@ struct Set: AsyncParsableCommand {
   var display: VMDisplayConfig?
 
   @Flag(inversion: .prefixedNo, help: ArgumentHelp("Whether to automatically reconfigure the VM's display to fit the window"))
-  var displayAutoReconfigure: Bool? = nil
+  var displayRefit: Bool? = nil
 
   @Flag(help: ArgumentHelp("Generate a new random MAC address for the VM."))
   var randomMAC: Bool = false
@@ -66,7 +66,7 @@ struct Set: AsyncParsableCommand {
       }
     }
 
-    vmConfig.displayAutoReconfigure = displayAutoReconfigure
+    vmConfig.displayRefit = displayRefit
 
     if randomMAC {
       vmConfig.macAddress = VZMACAddress.randomLocallyAdministered()

--- a/Sources/tart/Commands/Set.swift
+++ b/Sources/tart/Commands/Set.swift
@@ -17,6 +17,9 @@ struct Set: AsyncParsableCommand {
   @Option(help: "VM display resolution in a format of <width>x<height>. For example, 1200x800")
   var display: VMDisplayConfig?
 
+  @Flag(inversion: .prefixedNo, help: ArgumentHelp("Whether to automatically reconfigure the VM's display to fit the window"))
+  var displayAutoReconfigure: Bool? = nil
+
   @Flag(help: ArgumentHelp("Generate a new random MAC address for the VM."))
   var randomMAC: Bool = false
 
@@ -62,6 +65,8 @@ struct Set: AsyncParsableCommand {
         vmConfig.display.height = display.height
       }
     }
+
+    vmConfig.displayAutoReconfigure = displayAutoReconfigure
 
     if randomMAC {
       vmConfig.macAddress = VZMACAddress.randomLocallyAdministered()

--- a/Sources/tart/VMConfig.swift
+++ b/Sources/tart/VMConfig.swift
@@ -24,7 +24,7 @@ enum CodingKeys: String, CodingKey {
   case memorySize
   case macAddress
   case display
-  case displayAutoReconfigure
+  case displayRefit
 
   // macOS-specific keys
   case ecid
@@ -53,7 +53,7 @@ struct VMConfig: Codable {
   private(set) var memorySize: UInt64
   var macAddress: VZMACAddress
   var display: VMDisplayConfig = VMDisplayConfig()
-  var displayAutoReconfigure: Bool?
+  var displayRefit: Bool?
 
   init(
     platform: Platform,
@@ -123,7 +123,7 @@ struct VMConfig: Codable {
     self.macAddress = macAddress
 
     display = try container.decodeIfPresent(VMDisplayConfig.self, forKey: .display) ?? VMDisplayConfig()
-    displayAutoReconfigure = try container.decodeIfPresent(Bool.self, forKey: .displayAutoReconfigure)
+    displayRefit = try container.decodeIfPresent(Bool.self, forKey: .displayRefit)
   }
 
   func encode(to encoder: Encoder) throws {
@@ -139,8 +139,8 @@ struct VMConfig: Codable {
     try container.encode(memorySize, forKey: .memorySize)
     try container.encode(macAddress.string, forKey: .macAddress)
     try container.encode(display, forKey: .display)
-    if let displayAutoReconfigure = displayAutoReconfigure {
-      try container.encode(displayAutoReconfigure, forKey: .displayAutoReconfigure)
+    if let displayRefit = displayRefit {
+      try container.encode(displayRefit, forKey: .displayRefit)
     }
   }
 

--- a/Sources/tart/VMConfig.swift
+++ b/Sources/tart/VMConfig.swift
@@ -23,7 +23,9 @@ enum CodingKeys: String, CodingKey {
   case memorySizeMin
   case memorySize
   case macAddress
+
   case display
+  case displayAutoReconfigure
 
   // macOS-specific keys
   case ecid
@@ -51,7 +53,9 @@ struct VMConfig: Codable {
   var memorySizeMin: UInt64
   private(set) var memorySize: UInt64
   var macAddress: VZMACAddress
+
   var display: VMDisplayConfig = VMDisplayConfig()
+  var displayAutoReconfigure: Bool?
 
   init(
     platform: Platform,
@@ -121,6 +125,7 @@ struct VMConfig: Codable {
     self.macAddress = macAddress
 
     display = try container.decodeIfPresent(VMDisplayConfig.self, forKey: .display) ?? VMDisplayConfig()
+    displayAutoReconfigure = try container.decodeIfPresent(Bool.self, forKey: .displayAutoReconfigure)
   }
 
   func encode(to encoder: Encoder) throws {
@@ -136,6 +141,9 @@ struct VMConfig: Codable {
     try container.encode(memorySize, forKey: .memorySize)
     try container.encode(macAddress.string, forKey: .macAddress)
     try container.encode(display, forKey: .display)
+    if let displayAutoReconfigure = displayAutoReconfigure {
+      try container.encode(displayAutoReconfigure, forKey: .displayAutoReconfigure)
+    }
   }
 
   mutating func setCPU(cpuCount: Int) throws {

--- a/Sources/tart/VMConfig.swift
+++ b/Sources/tart/VMConfig.swift
@@ -23,7 +23,6 @@ enum CodingKeys: String, CodingKey {
   case memorySizeMin
   case memorySize
   case macAddress
-
   case display
   case displayAutoReconfigure
 
@@ -53,7 +52,6 @@ struct VMConfig: Codable {
   var memorySizeMin: UInt64
   private(set) var memorySize: UInt64
   var macAddress: VZMACAddress
-
   var display: VMDisplayConfig = VMDisplayConfig()
   var displayAutoReconfigure: Bool?
 


### PR DESCRIPTION
A simpler approach with direct `VMConfig.displayAutoReconfigure` access, inverted flag (to support prepending `--no-*`) and backwards compatibility (according to [the truth table](https://github.com/cirruslabs/tart/pull/951#issuecomment-2483611581)).

/cc @Fred78290

Resolves https://github.com/cirruslabs/tart/pull/951.