### PR TITLE
Better message if hardware model is not supported by the host

### DIFF
--- a/Sources/tart/Platform/Darwin.swift
+++ b/Sources/tart/Platform/Darwin.swift
@@ -38,7 +38,7 @@ struct UnsupportedHostOSError: Error, CustomStringConvertible {
         throw DecodingError.dataCorruptedError(forKey: .hardwareModel, in: container, debugDescription: "")
       }
       guard let hardwareModel = VZMacHardwareModel.init(dataRepresentation: data) else {
-        throw DecodingError.dataCorruptedError(forKey: .hardwareModel, in: container, debugDescription: "")
+        throw UnsupportedHostOSError()
       }
       self.hardwareModel = hardwareModel
     }


### PR DESCRIPTION
Related to https://github.com/cirruslabs/tart/discussions/961

It seems `VZMacHardwareModel#init?(dataRepresentation: Data)` is nullable sometimes. Let's return a better message in this case.