### PR TITLE
Fetcher: re-use URLSession

### DIFF
--- a/Sources/tart/Fetcher.swift
+++ b/Sources/tart/Fetcher.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-fileprivate var urlSessionConfiguration: URLSessionConfiguration {
+fileprivate var urlSession: URLSession = {
   let config = URLSessionConfiguration.default
 
   // Harbor expects a CSRF token to be present if the HTTP client
@@ -13,14 +13,15 @@ fileprivate var urlSessionConfiguration: URLSessionConfiguration {
   // [2]: https://github.com/cirruslabs/tart/issues/295
   config.httpShouldSetCookies = false
 
-  return config
-}
+  return URLSession(configuration: config)
+}()
 
 class Fetcher {
   static func fetch(_ request: URLRequest, viaFile: Bool = false, progress: Progress? = nil) async throws -> (AsyncThrowingStream<Data, Error>, HTTPURLResponse) {
+    let task = urlSession.dataTask(with: request)
+
     let delegate = Delegate()
-    let session = URLSession(configuration: urlSessionConfiguration, delegate: delegate, delegateQueue: nil)
-    let task = session.dataTask(with: request)
+    task.delegate = delegate
 
     let stream = AsyncThrowingStream<Data, Error> { continuation in
       delegate.streamContinuation = continuation


### PR DESCRIPTION
Otherwise we start to periodically get RST's from GitHub, possibly because of too many connection opens, which has an effect of cancelling previously received bytes.

These RST's can be observed in tcpdump/Wireshark or Console, emitted from the libusrtcp.dylib library, com.apple.network subsystem, for the Tart process:

```
tcp_input [C59.1.1.1:3] flags=[R] seq=1805021659, ack=0, win=0 state=CLOSED rcv_nxt=1805021659, snd_una=1752355607
```

You can also observe the "Received Bytes" in "Activity Monitor" for the Tart process while pulling `ghcr.io/cirruslabs/macos-runner:sequoia, and this value will periodically` decrease.