### PR TITLE
Replace the dummy console device by a true console device

### DIFF
--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -392,7 +392,7 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
 
     // Version console device
     //
-    // A dummy console device useful for implementing
+    // A console device useful for implementing
     // host feature checks in the guest agent software.
     if !suspendable {
       let consoleURL: URL = URL(fileURLWithPath: "tart-agent.sock", isDirectory: false, relativeTo: diskURL).absoluteURL

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -395,9 +395,16 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     // A dummy console device useful for implementing
     // host feature checks in the guest agent software.
     if !suspendable {
+      let consoleURL: URL = URL(fileURLWithPath: "tart-agent.sock", isDirectory: false, relativeTo: diskURL).absoluteURL
       let consolePort = VZVirtioConsolePortConfiguration()
-      consolePort.name = "tart-version-\(CI.version)"
 
+      if FileManager.default.fileExists(atPath: consoleURL.absoluteURL.path()) == false {
+        FileManager.default.createFile(atPath: consoleURL.absoluteURL.path(), contents: nil)
+      }
+
+      consolePort.name = "tart-agent"
+      consolePort.attachment = VZFileHandleSerialPortAttachment(fileHandleForReading: try FileHandle(forReadingFrom: consoleURL), fileHandleForWriting: try FileHandle(forWritingTo: consoleURL))
+      
       let consoleDevice = VZVirtioConsoleDeviceConfiguration()
       consoleDevice.ports[0] = consolePort
 

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -404,7 +404,7 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
 
       consolePort.name = "tart-agent"
       consolePort.attachment = VZFileHandleSerialPortAttachment(fileHandleForReading: try FileHandle(forReadingFrom: consoleURL), fileHandleForWriting: try FileHandle(forWritingTo: consoleURL))
-      
+
       let consoleDevice = VZVirtioConsoleDeviceConfiguration()
       consoleDevice.ports[0] = consolePort
 


### PR DESCRIPTION
The goal of this pull request is to replace the unusable dummy console device by a useful console device

In fact, the virtio socket is created in the guest machine but the host virtio socket is not created.

Now the console device is renamed tart-agent and the host socket file named tart-agent.sock is create inside the VM directory.

By this way, we can add some agent like incus or LXD to communicate between host and guest.