### PR TITLE
tart run: introduce --net-softnet-expose

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -190,6 +190,9 @@ struct Run: AsyncParsableCommand {
   @Option(help: ArgumentHelp("Comma-separated list of CIDRs to allow the traffic to when using Softnet isolation\n(e.g. --net-softnet-allow=192.168.0.0/24)", valueName: "comma-separated CIDRs"))
   var netSoftnetAllow: String?
 
+  @Option(help: ArgumentHelp("Comma-separated list of TCP ports to expose (e.g. --net-softnet-expose 2222:22,8080:80)", valueName: "comma-separated port specifications"))
+  var netSoftnetExpose: String?
+
   @Flag(help: ArgumentHelp("Restrict network access to the host-only network"))
   var netHost: Bool = false
 
@@ -525,6 +528,10 @@ struct Run: AsyncParsableCommand {
 
     if let netSoftnetAllow = netSoftnetAllow {
       softnetExtraArguments += ["--allow", netSoftnetAllow]
+    }
+
+    if let netSoftnetExpose = netSoftnetExpose {
+      softnetExtraArguments += ["--expose", netSoftnetExpose]
     }
 
     if netSoftnet {

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -190,7 +190,13 @@ struct Run: AsyncParsableCommand {
   @Option(help: ArgumentHelp("Comma-separated list of CIDRs to allow the traffic to when using Softnet isolation\n(e.g. --net-softnet-allow=192.168.0.0/24)", valueName: "comma-separated CIDRs"))
   var netSoftnetAllow: String?
 
-  @Option(help: ArgumentHelp("Comma-separated list of TCP ports to expose (e.g. --net-softnet-expose 2222:22,8080:80)", valueName: "comma-separated port specifications"))
+  @Option(help: ArgumentHelp("Comma-separated list of TCP ports to expose (e.g. --net-softnet-expose 2222:22,8080:80)", discussion: """
+  Options are comma-separated and are as follows:
+
+  * EXTERNAL_PORT:INTERNAL_PORT — forward TCP traffic from the EXTERNAL_PORT on a host's egress interface (automatically detected and could be Wi-Fi, Ethernet and a VPN interface) to the INTERNAL_PORT on guest's IP (as reported by "tart ip")
+
+  Note that your software should either listen on 0.0.0.0 inside of a VM or on an IP address assigned to that VM for the port forwarding to work correctly.
+  """, valueName: "comma-separated port specifications"))
   var netSoftnetExpose: String?
 
   @Flag(help: ArgumentHelp("Restrict network access to the host-only network"))

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -197,7 +197,7 @@ struct Run: AsyncParsableCommand {
 
   Note that your software should either listen on 0.0.0.0 inside of a VM or on an IP address assigned to that VM for the port forwarding to work correctly.
 
-  Another thing to keep in mind is that regular Softnet restrictions will still apply even to port forwarding. So if you're planning to access your VM from LAN, and your LAN is 192.168.0.0/24, for example, then add --net-softnet-allow=192.168.0.0/24. If you only need port forwarding, to completely disable Softnet restrictions you can use --net-softnet-allow=0.0.0.0/0.
+  Another thing to keep in mind is that regular Softnet restrictions will still apply even to port forwarding. So if you're planning to access your VM from local network, and your local network is 192.168.0.0/24, for example, then add --net-softnet-allow=192.168.0.0/24. If you only need port forwarding, to completely disable Softnet restrictions you can use --net-softnet-allow=0.0.0.0/0.
   """, valueName: "comma-separated port specifications"))
   var netSoftnetExpose: String?
 

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -196,6 +196,8 @@ struct Run: AsyncParsableCommand {
   * EXTERNAL_PORT:INTERNAL_PORT — forward TCP traffic from the EXTERNAL_PORT on a host's egress interface (automatically detected and could be Wi-Fi, Ethernet and a VPN interface) to the INTERNAL_PORT on guest's IP (as reported by "tart ip")
 
   Note that your software should either listen on 0.0.0.0 inside of a VM or on an IP address assigned to that VM for the port forwarding to work correctly.
+
+  Another thing to keep in mind is that regular Softnet restrictions will still apply even to port forwarding. So if you're planning to access your VM from LAN, and your LAN is 192.168.0.0/24, for example, then add --net-softnet-allow=192.168.0.0/24. If you only need port forwarding, to completely disable Softnet restrictions you can use --net-softnet-allow=0.0.0.0/0.
   """, valueName: "comma-separated port specifications"))
   var netSoftnetExpose: String?
 


### PR DESCRIPTION
Softnet's side: https://github.com/cirruslabs/softnet/pull/70.

Note that Softnet limitations still apply. This means that for exposing the VMs ports to the LAN, you might probably want to add something like `--net-softnet-allow=192.168.0.0/24` or use `--net-softnet-allow=0.0.0.0/0` if you don't need Softnet protection.

See https://github.com/cirruslabs/tart/discussions/855.