### PR TITLE
tart run: automatically enable --net-softnet when its related opts used

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -205,6 +205,8 @@ struct Run: AsyncParsableCommand {
   This option allows you bypass the private IPv4 address space restrctions imposed by --net-softnet.
 
   For example, you can allow the VM to communicate with the local network with e.g. --net-softnet-allow=10.0.0.0/16 or to completely disable the destination based restrictions with --net-softnet-allow=0.0.0.0/0.
+
+  Implies --net-softnet.
   """, valueName: "comma-separated CIDRs"))
   var netSoftnetAllow: String?
 
@@ -216,6 +218,8 @@ struct Run: AsyncParsableCommand {
   Note that your software should either listen on 0.0.0.0 inside of a VM or on an IP address assigned to that VM for the port forwarding to work correctly.
 
   Another thing to keep in mind is that regular Softnet restrictions will still apply even to port forwarding. So if you're planning to access your VM from local network, and your local network is 192.168.0.0/24, for example, then add --net-softnet-allow=192.168.0.0/24. If you only need port forwarding, to completely disable Softnet restrictions you can use --net-softnet-allow=0.0.0.0/0.
+
+  Implies --net-softnet.
   """, valueName: "comma-separated port specifications"))
   var netSoftnetExpose: String?
 
@@ -258,7 +262,12 @@ struct Run: AsyncParsableCommand {
       throw ValidationError("--vnc and --vnc-experimental are mutually exclusive")
     }
 
-    // check that not more than one network option is specified
+    // Automatically enable --net-softnet when any of its related options are specified
+    if netSoftnetAllow != nil || netSoftnetExpose != nil {
+      netSoftnet = true
+    }
+
+    // Check that no more than one network option is specified
     var netFlags = 0
     if netBridged.count > 0 { netFlags += 1 }
     if netSoftnet { netFlags += 1 }


### PR DESCRIPTION
Currently we don't validate this, so it's prone to error.

Another option is explicitly requiring `--net-softnet` when `--net-softnet--allow` and/or `--net-softnet-expose` are specified.