### PR TITLE
.goreleaser.yml: caveats stanza with DHCP fix information

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,13 @@ brews:
     repository:
       owner: cirruslabs
       name: homebrew-cli
-    caveats: See the GitHub repository for more information
+    caveats: |
+      Tart has been installed. You might want to reduce the default DHCP lease time
+      from 86,400 to 600 seconds to avoid DHCP shortage when running lots of VMs daily:
+
+        sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.InternetSharing.default.plist bootpd -dict DHCPLeaseTimeSecs -int 600
+
+      See https://tart.run/faq/#changing-the-default-dhcp-lease-time for more details.
     homepage: https://github.com/cirruslabs/tart
     license: "Fair Source"
     description: Run macOS and Linux VMs on Apple Hardware


### PR DESCRIPTION
See https://github.com/cirruslabs/tart/issues/998#issuecomment-2596105372.