### PR TITLE
Make tart set --random-serial no-op for Linux VMs

### DIFF
--- a/Sources/tart/Commands/Set.swift
+++ b/Sources/tart/Commands/Set.swift
@@ -73,8 +73,7 @@ struct Set: AsyncParsableCommand {
     }
 
     #if arch(arm64)
-      if randomSerial {
-        let oldPlatform = vmConfig.platform as! Darwin
+      if randomSerial, let oldPlatform = vmConfig.platform as? Darwin {
         vmConfig.platform = Darwin(ecid: VZMacMachineIdentifier(), hardwareModel: oldPlatform.hardwareModel)
       }
     #endif


### PR DESCRIPTION
Otherwise it crashes:

```
% tart set --random-serial linux
Could not cast value of type 'tart.Linux' (0x105010648) to 'tart.Darwin' (0x10500ec18).
zsh: abort      tart set --random-serial linux
```