### PR TITLE
tart run: allow "--dir" with "--suspendable"

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -320,9 +320,6 @@ struct Run: AsyncParsableCommand {
       if !(config.platform is PlatformSuspendable) {
         throw ValidationError("You can only suspend macOS VMs")
       }
-      if dir.count > 0 {
-        throw ValidationError("Suspending VMs with shared directories is not supported")
-      }
 
       if noTrackpad {
         throw ValidationError("--no-trackpad cannot be used with --suspendable")


### PR DESCRIPTION
Suspending and resuming a VM with shared directories seems to be now working on:

* `ghcr.io/cirruslabs/macos-sequoia-base:latest`
* `ghcr.io/cirruslabs/macos-sonoma-base:latest`
* `ghcr.io/cirruslabs/macos-ventura-base:latest`

...and macOS 15.5 (Sequoia) host.

Haven't checked Monterey since [it's EOL](https://en.wikipedia.org/wiki/MacOS#Timeline_of_releases).

Resolves https://github.com/cirruslabs/tart/issues/1081.