### PR TITLE
 Allow VM window to be resized smaller than its configured resolution

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -745,10 +745,8 @@ struct MainApp: App {
           }
         }
       }.frame(
-        minWidth: CGFloat(vm!.config.display.width),
         idealWidth: CGFloat(vm!.config.display.width),
         maxWidth: .infinity,
-        minHeight: CGFloat(vm!.config.display.height),
         idealHeight: CGFloat(vm!.config.display.height),
         maxHeight: .infinity
       )


### PR DESCRIPTION
Allow the VM window to be resized below its configured display resolution by removing the `minWidth`/`minHeight` constraints in `Run.swift`. This lets users on smaller host screens shrink the window for better multitasking.

See issue #1087