### PR TITLE
tart exec: make sure <name> goes after flags like -i and -t in --help

### DIFF
--- a/Sources/tart/Commands/Exec.swift
+++ b/Sources/tart/Commands/Exec.swift
@@ -15,14 +15,14 @@ struct Exec: AsyncParsableCommand {
   Note that all non-vanilla Cirrus Labs VM images already have the Tart Guest Agent installed.
   """)
 
-  @Argument(help: "VM name", completion: .custom(completeLocalMachines))
-  var name: String
-
   @Flag(name: [.customShort("i")], help: "Attach host's standard input to a remote command")
   var interactive: Bool = false
 
   @Flag(name: [.customShort("t")], help: "Allocate a remote pseudo-terminal (PTY)")
   var tty: Bool = false
+
+  @Argument(help: "VM name", completion: .custom(completeLocalMachines))
+  var name: String
 
   @Argument(parsing: .captureForPassthrough, help: "Command to execute")
   var command: [String]


### PR DESCRIPTION
See https://github.com/cirruslabs/tart/discussions/1089.