### PR TITLE
Add --no-keyboard, --no-pointer options for run

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -273,6 +273,12 @@ struct Run: AsyncParsableCommand {
   #endif
   var noTrackpad: Bool = false
 
+  @Flag(help: ArgumentHelp("Disable the pointer"))
+  var noPointer: Bool = false
+
+  @Flag(help: ArgumentHelp("Disable the keyboard"))
+  var noKeyboard: Bool = false
+
   mutating func validate() throws {
     if vnc && vncExperimental {
       throw ValidationError("--vnc and --vnc-experimental are mutually exclusive")
@@ -324,7 +330,14 @@ struct Run: AsyncParsableCommand {
       if noTrackpad {
         throw ValidationError("--no-trackpad cannot be used with --suspendable")
       }
+      if noKeyboard {
+        throw ValidationError("--no-keyboard cannot be used with --suspendable")
+      }
+      if noPointer {
+        throw ValidationError("--no-pointer cannot be used with --suspendable")
+      }
     }
+
 
     if noTrackpad {
       let config = try VMConfig.init(fromURL: vmDir.configURL)
@@ -395,7 +408,9 @@ struct Run: AsyncParsableCommand {
       clipboard: !noClipboard,
       sync: VZDiskImageSynchronizationMode(diskOptions.syncModeRaw),
       caching: VZDiskImageCachingMode(diskOptions.cachingModeRaw),
-      noTrackpad: noTrackpad
+      noTrackpad: noTrackpad,
+      noPointer: noPointer,
+      noKeyboard: noKeyboard
     )
 
     let vncImpl: VNC? = try {

--- a/Sources/tart/VM.swift
+++ b/Sources/tart/VM.swift
@@ -51,7 +51,9 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
        clipboard: Bool = true,
        sync: VZDiskImageSynchronizationMode = .full,
        caching: VZDiskImageCachingMode? = nil,
-       noTrackpad: Bool = false
+       noTrackpad: Bool = false,
+       noPointer: Bool = false,
+       noKeyboard: Bool = false
   ) throws {
     name = vmDir.name
     config = try VMConfig.init(fromURL: vmDir.configURL)
@@ -73,7 +75,9 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
                                                 clipboard: clipboard,
                                                 sync: sync,
                                                 caching: caching,
-                                                noTrackpad: noTrackpad
+                                                noTrackpad: noTrackpad,
+                                                noPointer: noPointer,
+                                                noKeyboard: noKeyboard
     )
     virtualMachine = VZVirtualMachine(configuration: configuration)
 
@@ -314,7 +318,9 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
     clipboard: Bool = true,
     sync: VZDiskImageSynchronizationMode = .full,
     caching: VZDiskImageCachingMode? = nil,
-    noTrackpad: Bool = false
+    noTrackpad: Bool = false,
+    noPointer: Bool = false,
+    noKeyboard: Bool = false
   ) throws -> VZVirtualMachineConfiguration {
     let configuration = VZVirtualMachineConfiguration()
 
@@ -354,8 +360,16 @@ class VM: NSObject, VZVirtualMachineDelegate, ObservableObject {
       configuration.keyboards = platformSuspendable.keyboardsSuspendable()
       configuration.pointingDevices = platformSuspendable.pointingDevicesSuspendable()
     } else {
-      configuration.keyboards = vmConfig.platform.keyboards()
-      if noTrackpad {
+
+      if noKeyboard {
+        configuration.keyboards = []
+      } else {
+        configuration.keyboards = vmConfig.platform.keyboards()
+      }
+
+      if noPointer {
+        configuration.pointingDevices = []
+      } else if noTrackpad {
         configuration.pointingDevices = vmConfig.platform.pointingDevicesSimplified()
       } else {
         configuration.pointingDevices = vmConfig.platform.pointingDevices()


### PR DESCRIPTION
This adds two new flags `--no-keyboard` and `--no-pointer` to the `tart run` command.  These are available with UTM and I have found them useful when running automated tasks to avoid interfering with execution.  I have confirmed that these options work with both MacOS vms and Ubuntu vms.