### PR TITLE
ASIF is available only starting from macOS 26 (Tahoe)

### DIFF
--- a/Sources/tart/DiskImageFormat.swift
+++ b/Sources/tart/DiskImageFormat.swift
@@ -21,7 +21,7 @@ enum DiskImageFormat: String, CaseIterable, Codable {
     case .raw:
       return true
     case .asif:
-      if #available(macOS 15, *) {
+      if #available(macOS 26, *) {
         return true
       } else {
         return false


### PR DESCRIPTION
It's not available on macOS 15 (Sequoia).