### PR TITLE
tart clone: cap automatic pruning at 100 GB

### DIFF
--- a/Sources/tart/Commands/Clone.swift
+++ b/Sources/tart/Commands/Clone.swift
@@ -76,8 +76,10 @@ struct Clone: AsyncParsableCommand {
       //
       // So, once we clone the VM let's try to claim the rest of space for the VM to run without errors.
       let unallocatedBytes = try sourceVM.sizeBytes() - sourceVM.allocatedSizeBytes()
-      if unallocatedBytes > 0 {
-        try Prune.reclaimIfNeeded(UInt64(unallocatedBytes), sourceVM)
+      // Avoid reclaiming an excessive amount of disk space.
+      let reclaimBytes = min(unallocatedBytes, 100 * 1024 * 1024 * 1024)
+      if reclaimBytes > 0 {
+        try Prune.reclaimIfNeeded(UInt64(reclaimBytes), sourceVM)
       }
     }, onCancel: {
       try? FileManager.default.removeItem(at: tmpVMDir.baseURL)


### PR DESCRIPTION
## Summary
- avoid reclaiming more than 100 GB of disk space during `tart clone`

## Testing
- `swift test` *(fails: failed to clone repository: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c62c5a4ee08329961b89915d85f486