### PR TITLE
Do not fail fast when iterating over credential providers

### DIFF
--- a/Sources/tart/Commands/Login.swift
+++ b/Sources/tart/Commands/Login.swift
@@ -64,6 +64,8 @@ struct Login: AsyncParsableCommand {
 }
 
 fileprivate class DictionaryCredentialsProvider: CredentialsProvider {
+  let userFriendlyName = "static dictionary credentials provider"
+
   var credentials: Dictionary<String, (String, String)>
 
   init(_ credentials: Dictionary<String, (String, String)>) {

--- a/Sources/tart/Credentials/CredentialsProvider.swift
+++ b/Sources/tart/Credentials/CredentialsProvider.swift
@@ -5,6 +5,7 @@ enum CredentialsProviderError: Error {
 }
 
 protocol CredentialsProvider {
+  var userFriendlyName: String { get }
   func retrieve(host: String) throws -> (String, String)?
   func store(host: String, user: String, password: String) throws
 }

--- a/Sources/tart/Credentials/DockerConfigCredentialsProvider.swift
+++ b/Sources/tart/Credentials/DockerConfigCredentialsProvider.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 class DockerConfigCredentialsProvider: CredentialsProvider {
+  let userFriendlyName = "Docker configuration credentials provider"
+
   func retrieve(host: String) throws -> (String, String)? {
     let dockerConfigURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".docker").appendingPathComponent("config.json")
     if !FileManager.default.fileExists(atPath: dockerConfigURL.path) {

--- a/Sources/tart/Credentials/EnvironmentCredentialsProvider.swift
+++ b/Sources/tart/Credentials/EnvironmentCredentialsProvider.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 class EnvironmentCredentialsProvider: CredentialsProvider {
+  let userFriendlyName = "environment variable credentials provider"
+
   func retrieve(host: String) throws -> (String, String)? {
     if let tartRegistryHostname = ProcessInfo.processInfo.environment["TART_REGISTRY_HOSTNAME"],
        tartRegistryHostname != host {

--- a/Sources/tart/Credentials/KeychainCredentialsProvider.swift
+++ b/Sources/tart/Credentials/KeychainCredentialsProvider.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 class KeychainCredentialsProvider: CredentialsProvider {
+  let userFriendlyName = "Keychain credentials provider"
+
   func retrieve(host: String) throws -> (String, String)? {
     let query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
                                 kSecAttrProtocol as String: kSecAttrProtocolHTTPS,

--- a/Sources/tart/Credentials/StdinCredentials.swift
+++ b/Sources/tart/Credentials/StdinCredentials.swift
@@ -6,6 +6,8 @@ enum StdinCredentialsError: Error {
 }
 
 class StdinCredentials {
+  let userFriendlyName = "standard input credentials provider"
+
   static func retrieve() throws -> (String, String) {
     let user = try readStdinCredential(name: "username", prompt: "User: ", isSensitive: false)
     let password = try readStdinCredential(name: "password", prompt: "Password: ", isSensitive: true)

--- a/Sources/tart/OCI/Registry.swift
+++ b/Sources/tart/OCI/Registry.swift
@@ -429,8 +429,12 @@ class Registry {
     }
 
     for provider in credentialsProviders {
-      if let (user, password) = try provider.retrieve(host: host) {
-        return (user, password)
+      do {
+        if let (user, password) = try provider.retrieve(host: host) {
+          return (user, password)
+        }
+      } catch (let e) {
+        print("Failed to retrieve credentials using \(provider.userFriendlyName), authentication may fail: \(e)")
       }
     }
     return nil


### PR DESCRIPTION
https://github.com/cirruslabs/tart/issues/1129 was likely caused by an invalid `~/.docker/config.json`, see https://github.com/cirruslabs/tart/issues/1129#issuecomment-3305016175.

Do not fail fast when iterating over credential helpers and simply log an attributed error instead.

Before:

```
pulling ghcr.io/cirruslabs/macos-sonoma-base:latest...
pulling manifest...
Error: dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: Optional(Error Domain=NSCocoaErrorDomain Code=3840 "Unexpected end of file" UserInfo={NSDebugDescription=Unexpected end of file})))
```

After:

```
pulling ghcr.io/cirruslabs/macos-sonoma-base:latest...
pulling manifest...
Failed to retrieve credentials using Docker configuration credentials provider, authentication may fail: dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: Optional(Error Domain=NSCocoaErrorDomain Code=3840 "Unexpected end of file" UserInfo={NSDebugDescription=Unexpected end of file})))
pulling disk (20.4 GB compressed)...
1%
```