### PR TITLE
Avoid duplicate progress updates in CI logs

### DIFF
--- a/Sources/tart/Logging/ProgressObserver.swift
+++ b/Sources/tart/Logging/ProgressObserver.swift
@@ -20,7 +20,7 @@ public class ProgressObserver: NSObject {
         self.lastTimeUpdated = currentTime
         let line = ProgressObserver.lineToRender(self.progressToObserve)
         // Skip identical renders so non-interactive logs only see new percent values.
-        guard line != self.lastRenderedLine else {
+        if line == self.lastRenderedLine {
           return
         }
 


### PR DESCRIPTION
We run tart inside a GitHub Action and noticed that progress updates flood the log because the non-interactive console prints every updateLastLine call, even when the percentage hasn’t actually changed. 

With this change the ProgressObserver remembers the last rendered percentage and skips redundant updates, so the action log now shows each percent only once while keeping interactive behavior unchanged.