### PR TITLE
Update faq.md: Use question word order in subheading

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -150,7 +150,7 @@ This command also supports the `-p` command-line argument that allows you to sup
 
 If that doesn't work for you for some reason, you can pass the credentials via the environment variables, see [Registry Authorization](integrations/vm-management.md#registry-authorization) for more details on how to do that.
 
-## How Tart is different from Anka?
+## How is Tart different from Anka?
 
 Under the hood Tart is using the same technology as Anka 3.0 so there should be no real difference in performance
 or features supported. If there is some feature missing please don't hesitate to [create a feature request](https://github.com/cirruslabs/tart/issues).


### PR DESCRIPTION
"How Tart is different from Anka" is not a question, and thus should not have a question mark. This PR proposes to change it into a question, but an equally valid fix is to drop the question mark.