### PR TITLE
FAQ: document creation and unlocking of the keychain headless machines

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -27,7 +27,7 @@ Logging in graphically will automatically create the `login.keychain`. Afterward
     * this will maintain a running user session (GUI) even after the machine reboots
     * moreover, you can still lock the screen (either manually [or automatically](https://support.apple.com/guide/mac-help/change-lock-screen-settings-on-mac-mh11784/mac)), however, the security benefit of this is questionable
 * use `security unlock-keychain login.keychain` to unlock the login keychain via the terminal
-    * this commands also supports the `-p` command-line argument, which allows you to supply a password and unlock non-interactively
+    * this command also supports the `-p` command-line argument, which allows you to supply a password and unlock non-interactively
 
 ### Create and unlock the login keychain via the terminal
 


### PR DESCRIPTION
To work around errors like:

* `SecKeyCreateRandomKey_ios failed`
* `Failed to generate keypair`
* `Interaction is not allowed with the Security Server`

...when running `tart run` on headless machines like the ones provided by AWS EC2.

Related issues:

* https://github.com/cirruslabs/tart/issues/1146
* https://github.com/cirruslabs/tart/issues/1137
* https://github.com/cirruslabs/tart/issues/1132
* https://github.com/cirruslabs/tart/issues/1067

Also specifically unlock `login.keychain` in "Running login/clone/pull/push commands over SSH" section, which should better indicate a missing keychain instead of doing nothing.