### PR TITLE
Fix VM window not appearing on tart run

### DIFF
--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -819,6 +819,12 @@ struct MainApp: App {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
+  func applicationDidFinishLaunching(_ : Notification) {
+    let nsApp = NSApplication.shared
+    nsApp.setActivationPolicy(.regular)
+    nsApp.activate(ignoringOtherApps: true)
+  }
+
   func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
     if (kill(getpid(), MainApp.suspendable ? SIGUSR1 : SIGINT) == 0) {
       return .terminateLater


### PR DESCRIPTION
Restore the applicationDidFinishLaunching method that was accidentally removed in commit b1e88e1 ("tart run: do not remove 'Edit' menu as its not present anymore").

That commit intended to remove the Edit menu removal code (since the menu no longer exists), but also removed the crucial activation code:
- setActivationPolicy(.regular) - tells macOS this is a GUI app
- activate(ignoringOtherApps:) - brings the window to the foreground

Without these calls, the VM runs fine (SSH works) but no window appears on screen.

Fixes #1181