### PR TITLE
Switch to github.com/open-telemetry/opentelemetry-swift fork

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5b17565466d26bfaa0fcb1b0ee11405dfe2c43ba46b7a7e30e9742537dadbad0",
+  "originHash" : "0da1cc30fa3c41e8c2e2edcdd55706549908275a54f681203e0eeade279deab9",
   "pins" : [
     {
       "identity" : "antlr4",
@@ -49,7 +49,7 @@
     {
       "identity" : "opentelemetry-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/edigaryev/opentelemetry-swift",
+      "location" : "https://github.com/cirruslabs/opentelemetry-swift",
       "state" : {
         "branch" : "use-feedback-handler",
         "revision" : "2040f383e2a8b0a568a7617d147f8f1e23abb298"

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     .package(url: "https://github.com/jozefizso/swift-xattr", from: "3.0.0"),
     .package(url: "https://github.com/grpc/grpc-swift.git", .upToNextMajor(from: "1.27.0")),
     .package(url: "https://buf.build/gen/swift/git/1.27.1-20260114140118-bd09c26a260f.1/cirruslabs_tart-guest-agent_grpc_swift.git", branch: "main"),
-    .package(url: "https://github.com/edigaryev/opentelemetry-swift", branch: "use-feedback-handler"),
+    .package(url: "https://github.com/cirruslabs/opentelemetry-swift", branch: "use-feedback-handler"),
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core", from: "2.3.0"),
 
   ],


### PR DESCRIPTION
While https://github.com/open-telemetry/opentelemetry-swift/pull/1036 is still not merged.

Resolves https://github.com/cirruslabs/tart/issues/1185.