### PR TITLE
Switch back to github.com/open-telemetry/opentelemetry-swift upstream

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0da1cc30fa3c41e8c2e2edcdd55706549908275a54f681203e0eeade279deab9",
+  "originHash" : "061dfe6cdf4e6dbf32b51c5e7023c4ae69726dcafb42a35b34e5489b0338c17f",
   "pins" : [
     {
       "identity" : "antlr4",
@@ -49,10 +49,10 @@
     {
       "identity" : "opentelemetry-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/cirruslabs/opentelemetry-swift",
+      "location" : "https://github.com/open-telemetry/opentelemetry-swift",
       "state" : {
-        "branch" : "use-feedback-handler",
-        "revision" : "2040f383e2a8b0a568a7617d147f8f1e23abb298"
+        "branch" : "main",
+        "revision" : "ed37be9525081509ab62410d38b705c2b3f0d5a4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     .package(url: "https://github.com/jozefizso/swift-xattr", from: "3.0.0"),
     .package(url: "https://github.com/grpc/grpc-swift.git", .upToNextMajor(from: "1.27.0")),
     .package(url: "https://buf.build/gen/swift/git/1.27.1-20260114140118-bd09c26a260f.1/cirruslabs_tart-guest-agent_grpc_swift.git", branch: "main"),
-    .package(url: "https://github.com/cirruslabs/opentelemetry-swift", branch: "use-feedback-handler"),
+    .package(url: "https://github.com/open-telemetry/opentelemetry-swift", branch: "main"),
     .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core", from: "2.3.0"),
 
   ],


### PR DESCRIPTION
Now that the both of the PRs are merged:

* https://github.com/open-telemetry/opentelemetry-swift/pull/1036
* https://github.com/open-telemetry/opentelemetry-swift/pull/1040

...we can in a way revert the https://github.com/cirruslabs/tart/pull/1186.