### PR TITLE
Bind and connect to Unix domain sockets using relative paths

### DIFF
--- a/Sources/tart/Commands/IP.swift
+++ b/Sources/tart/Commands/IP.swift
@@ -68,7 +68,15 @@ struct IP: AsyncParsableCommand {
           throw RuntimeError.Generic("Cannot perform IP resolution via Tart Guest Agent when control socket URL is not set")
         }
 
-        if let ip = try await AgentResolver.ResolveIP(controlSocketURL) {
+        // Change the current working directory to a VM's base directory
+        // to work around Unix domain socket 104 byte limitation [1]
+        //
+        // [1]: https://blog.8-p.info/en/2020/06/11/unix-domain-socket-length/
+        if let baseURL = controlSocketURL.baseURL {
+          FileManager.default.changeCurrentDirectoryPath(baseURL.path())
+        }
+
+        if let ip = try await AgentResolver.ResolveIP(controlSocketURL.relativePath) {
           return ip
         }
       }

--- a/Sources/tart/MACAddressResolver/AgentResolver.swift
+++ b/Sources/tart/MACAddressResolver/AgentResolver.swift
@@ -6,15 +6,15 @@ import Cirruslabs_TartGuestAgent_Apple_Swift
 import Cirruslabs_TartGuestAgent_Grpc_Swift
 
 class AgentResolver {
-  static func ResolveIP(_ controlSocketURL: URL) async throws -> IPv4Address? {
+  static func ResolveIP(_ controlSocketPath: String) async throws -> IPv4Address? {
     do {
-      return try await resolveIP(controlSocketURL)
+      return try await resolveIP(controlSocketPath)
     } catch let error as GRPCConnectionPoolError {
       return nil
     }
   }
 
-  private static func resolveIP(_ controlSocketURL: URL) async throws -> IPv4Address? {
+  private static func resolveIP(_ controlSocketPath: String) async throws -> IPv4Address? {
     // Create a gRPC channel connected to the VM's control socket
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer {
@@ -22,7 +22,7 @@ class AgentResolver {
     }
 
     let channel = try GRPCChannelPool.with(
-      target: .unixDomainSocket(controlSocketURL.path()),
+      target: .unixDomainSocket(controlSocketPath),
       transportSecurity: .plaintext,
       eventLoopGroup: group,
     )

--- a/Sources/tart/VMDirectory.swift
+++ b/Sources/tart/VMDirectory.swift
@@ -27,7 +27,7 @@ struct VMDirectory: Prunable {
     baseURL.appendingPathComponent("manifest.json")
   }
   var controlSocketURL: URL {
-    baseURL.appendingPathComponent("control.sock")
+    URL(fileURLWithPath: "control.sock", relativeTo: baseURL)
   }
 
   var explicitlyPulledMark: URL {


### PR DESCRIPTION
To work around Unix domain socket [`104` byte limitation](https://blog.8-p.info/en/2020/06/11/unix-domain-socket-length/) for its name.

We can treat this PR as a hot-fix and implement the following improvements in the upcoming PRs:

* only change working directory for a short period of time (to establish a Unix domain socket connection) and then restore it back
  * currently e.g. `--dir` works fine with a relative path, but it would be nice to limit the potential for issues with this in the long-term
* figure out how to control socket failures more evident
  * perhaps if we create early in the initial steps of `tart run`, we can avoid running a VM if its creation fails

Or we can do these as a part of this PR.