### PR TITLE
docs: document TART_REGISTRY_HOSTNAME

### DIFF
--- a/docs/integrations/vm-management.md
+++ b/docs/integrations/vm-management.md
@@ -116,7 +116,9 @@ In addition, Tart supports [Docker credential helpers](https://docs.docker.com/e
 if defined in `~/.docker/config.json`.
 
 Finally, `TART_REGISTRY_USERNAME` and `TART_REGISTRY_PASSWORD` environment variables allow to override authorization
-for all registries which might useful for integrating with your CI's secret management.
+for all registries, which might be useful for integrating with your CI's secret management.
+
+You can also set the `TART_REGISTRY_HOSTNAME` environment variable to apply these overrides only to a specific host.
 
 ### Pushing a Local Image
 


### PR DESCRIPTION
Only `TART_REGISTRY_USERNAME` and `TART_REGISTRY_PASSWORD` were documented for some reason.

See https://github.com/cirruslabs/orchard/issues/405#issuecomment-3893444765.