### PR TITLE
tart list: remove "SizeOnDisk" and add "Accessed" field

### DIFF
--- a/Sources/tart/Commands/List.swift
+++ b/Sources/tart/Commands/List.swift
@@ -7,7 +7,6 @@ fileprivate struct VMInfo: Encodable {
   let Name: String
   let Disk: Int
   let Size: Int
-  let SizeOnDisk: Int
   let Accessed: String
   let Running: Bool
   let State: String
@@ -45,7 +44,6 @@ struct List: AsyncParsableCommand {
           Name: name,
           Disk: vmDir.sizeGB(),
           Size: vmDir.allocatedSizeGB(),
-          SizeOnDisk: vmDir.allocatedSizeGB() - vmDir.deduplicatedSizeGB(),
           Accessed: formatAccessDate(try vmDir.accessDate()),
           Running: vmDir.running(),
           State: vmDir.state().rawValue
@@ -60,7 +58,6 @@ struct List: AsyncParsableCommand {
           Name: name,
           Disk: vmDir.sizeGB(),
           Size: vmDir.allocatedSizeGB(),
-          SizeOnDisk: vmDir.allocatedSizeGB() - vmDir.deduplicatedSizeGB(),
           Accessed: formatAccessDate(try vmDir.accessDate()),
           Running: vmDir.running(),
           State: vmDir.state().rawValue


### PR DESCRIPTION
Since https://github.com/cirruslabs/tart/pull/924, the `SizeOnDisk` field in `tart list` is pretty much always equal to `Size`.

Let's free up some space and add a hopefully more useful field `Accessed`, which allows users to better understand whether a certain VM image will get pruned soon or not:

```
Source Name                                                                                                           Disk Size Accessed       State  
local  macos                                                                                                          50   31   20 hours ago   stopped
OCI    ghcr.io/cirruslabs/macos-tahoe-base:latest                                                                     50   31   2 days ago     stopped
OCI    ghcr.io/cirruslabs/macos-tahoe-base@sha256:47766b0208ee19c6321ae2990961fc5418f7700769a572c11676571d4a85ab43    50   31   9 minutes ago  stopped
OCI    ghcr.io/cirruslabs/macos-tahoe-vanilla:latest                                                                  50   27   2 weeks ago    stopped
OCI    ghcr.io/cirruslabs/macos-tahoe-vanilla@sha256:932e8e1f4a294e065c03a2e121ce25be7f90e2a689501a61bff78a1d8c03749e 50   27   21 minutes ago stopped
OCI    ghcr.io/cirruslabs/ubuntu:latest                                                                               20   4    2 weeks ago    stopped
OCI    ghcr.io/cirruslabs/ubuntu@sha256:273b6ffb2ef4f3dbf2049081af262c3baf78ca61e71aeb732d67064d99edda21              20   4    2 weeks ago    stopped
```

Resolves https://github.com/cirruslabs/tart/issues/1190.