### PR TITLE
StdinCredentials: increase maxCharacters to 8,192

### DIFF
--- a/Sources/tart/Credentials/StdinCredentials.swift
+++ b/Sources/tart/Credentials/StdinCredentials.swift
@@ -15,7 +15,7 @@ class StdinCredentials {
     return (user, password)
   }
 
-  private static func readStdinCredential(name: String, prompt: String, maxCharacters: Int = 1024, isSensitive: Bool) throws -> String {
+  private static func readStdinCredential(name: String, prompt: String, maxCharacters: Int = 8192, isSensitive: Bool) throws -> String {
     var buf = [CChar](repeating: 0, count: maxCharacters + 1 /* sentinel */ + 1 /* NUL */)
     guard let rawCredential = readpassphrase(prompt, &buf, buf.count, isSensitive ? RPP_ECHO_OFF : RPP_ECHO_ON) else {
       throw StdinCredentialsError.CredentialRequired(which: name)


### PR DESCRIPTION
To handle OCI registry passwords/tokens larger than 1,024 characters.