### PR TITLE
Mention macOS Tahoe everywhere instead of macOS Sequoia

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,7 +40,7 @@ task:
   name: Lint
   alias: lint
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-runner:sequoia
+    image: ghcr.io/cirruslabs/macos-runner:tahoe
   lint_script:
     - swift package plugin --allow-writing-to-package-directory swiftformat --cache ignore --lint --report swiftformat.json .
   always:
@@ -57,7 +57,7 @@ task:
   name: Build ($BUILD_ARCH)
   alias: build
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-runner:sequoia
+    image: ghcr.io/cirruslabs/macos-runner:tahoe
   build_script: swift build --arch $BUILD_ARCH --product tart
   sign_script: codesign --sign - --entitlements Resources/tart-dev.entitlements --force .build/$BUILD_ARCH-apple-macosx/debug/tart
   binary_artifacts:
@@ -70,7 +70,7 @@ task:
     - lint
     - build
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-runner:sequoia
+    image: ghcr.io/cirruslabs/macos-runner:tahoe
   env:
     MACOS_CERTIFICATE: ENCRYPTED[552b9d275d1c2bdbc1bff778b104a8f9a53cbd0d59344d4b7f6d0ca3c811a5cefb97bef9ba0ef31c219cb07bdacdd2c2]
     AC_PASSWORD: ENCRYPTED[4a761023e7e06fe2eb350c8b6e8e7ca961af193cb9ba47605f25f1d353abc3142606f412e405be48fd897a78787ea8c2]
@@ -106,7 +106,7 @@ task:
     - test
     - build
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-runner:sequoia
+    image: ghcr.io/cirruslabs/macos-runner:tahoe
   env:
     MACOS_CERTIFICATE: ENCRYPTED[552b9d275d1c2bdbc1bff778b104a8f9a53cbd0d59344d4b7f6d0ca3c811a5cefb97bef9ba0ef31c219cb07bdacdd2c2]
     AC_PASSWORD: ENCRYPTED[4a761023e7e06fe2eb350c8b6e8e7ca961af193cb9ba47605f25f1d353abc3142606f412e405be48fd897a78787ea8c2]

--- a/PROFILING.md
+++ b/PROFILING.md
@@ -7,7 +7,7 @@ Perhaps, the easiest, but not the most comprehensive way to tell what's going on
 In the example below, you will run `tart pull` via `time(1)` to gather generalized CPU, I/O and memory usage metrics:
 
 ```shell
-/usr/bin/time -l tart pull ghcr.io/cirruslabs/macos-sequoia-base:latest
+/usr/bin/time -l tart pull ghcr.io/cirruslabs/macos-tahoe-base:latest
 ```
 
 **Note:** you need to specify a full path to `time(1)` binary, otherwise the shell's built-in `time` command will be invoked, which doesn't have the `-l` command-line argument.
@@ -48,7 +48,7 @@ To use it, make sure that [Xcode](https://developer.apple.com/xcode/resources/) 
 Once done, you can create a CPU profile of `tart pull`:
 
 ```shell
-xctrace record --template "CPU Profiler" --target-stdout - --launch -- /opt/homebrew/bin/tart pull ghcr.io/cirruslabs/macos-sequoia-base:latest
+xctrace record --template "CPU Profiler" --target-stdout - --launch -- /opt/homebrew/bin/tart pull ghcr.io/cirruslabs/macos-tahoe-base:latest
 ```
 
 Now that `xctrace(1)` is running, you'll see the `tart pull`-related output first, and once finished, the following line will appear:

--- a/Sources/tart/Commands/Run.swift
+++ b/Sources/tart/Commands/Run.swift
@@ -137,7 +137,7 @@ struct Run: AsyncParsableCommand {
   To work with block devices, the easiest way is to modify their permissions to be accessible to the current user:
 
   sudo chown $USER /dev/diskX
-  tart run sequoia --disk=/dev/diskX
+  tart run macos --disk=/dev/diskX
 
   Warning: after running the chown command above, all software running under the current user will be able to access /dev/diskX. If that violates your threat model, we recommend avoiding mounting block devices altogether.
   """, valueName: "path[:options]"), completion: .file())

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -13,7 +13,7 @@ brew install go
 Finally, run the following command from this (`benchmark/`) directory:
 
 ```shell
-go run cmd/main.go fio --image ghcr.io/cirruslabs/macos-sequoia-base:latest --prepare 'sudo purge && sync'
+go run cmd/main.go fio --image ghcr.io/cirruslabs/macos-tahoe-base:latest --prepare 'sudo purge && sync'
 ```
 
 You can also enable the debugging output to diagnose issues:

--- a/benchmark/internal/command/xcode/xcode.go
+++ b/benchmark/internal/command/xcode/xcode.go
@@ -23,7 +23,7 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&debug, "debug", false, "enable debug logging")
-	cmd.Flags().StringVar(&image, "image", "ghcr.io/cirruslabs/macos-sequoia-xcode:latest", "image to use for testing")
+	cmd.Flags().StringVar(&image, "image", "ghcr.io/cirruslabs/macos-tahoe-xcode:latest", "image to use for testing")
 	cmd.Flags().StringVar(&prepare, "prepare", "", "command to run before running each benchmark")
 
 	return cmd

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -59,7 +59,7 @@ Remote images are pulled into `~/.tart/cache/OCIs/`.
 ## Nested virtualization support?
 
 Tart is limited by functionality of Apple's `Virtualization.Framework`. At the moment `Virtualization.Framework`
-supports nested virtualization only on M3 or M4 chips running macOS 15 (Sequoia). By default, it is disabled, but can be enabled by passing the `--nested` flag to `tart run`.
+supports nested virtualization only on M3 or M4 chips running macOS 15 (Sequoia) or later. By default, it is disabled, but can be enabled by passing the `--nested` flag to `tart run`.
 
 ## Connecting to a service running on host
 

--- a/docs/integrations/buildkite.md
+++ b/docs/integrations/buildkite.md
@@ -18,9 +18,9 @@ steps:
 - command: uname -a
   plugins:
   - cirruslabs/tart#main:
-    image: ghcr.io/cirruslabs/macos-sequoia-base:latest
+    image: ghcr.io/cirruslabs/macos-tahoe-base:latest
 ```
 
-This will run `uname -r` in a macOS Tart VM cloned from `ghcr.io/cirruslabs/macos-sequoia-base:latest`.
+This will run `uname -r` in a macOS Tart VM cloned from `ghcr.io/cirruslabs/macos-tahoe-base:latest`.
 
 See plugin's [Configuration section](https://github.com/cirruslabs/tart-buildkite-plugin#configuration) for the full list of available options.

--- a/docs/integrations/cirrus-cli.md
+++ b/docs/integrations/cirrus-cli.md
@@ -18,7 +18,7 @@ task:
   name: hello
   macos_instance:
     # can be a remote or a local virtual machine
-    image: ghcr.io/cirruslabs/macos-sequoia-base:latest
+    image: ghcr.io/cirruslabs/macos-tahoe-base:latest
   hello_script:
     - echo "Hello from within a Tart VM!"
     - echo "Here is my CPU info:"
@@ -50,7 +50,7 @@ exposes it via [`artifacts` instruction](https://cirrus-ci.org/guide/writing-tas
 task:
   name: Build
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-sequoia-xcode:latest
+    image: ghcr.io/cirruslabs/macos-tahoe-xcode:latest
   build_script: swift build --product tart
   binary_artifacts:
     path: .build/debug/tart

--- a/docs/integrations/gitlab-runner.md
+++ b/docs/integrations/gitlab-runner.md
@@ -42,7 +42,7 @@ Now you can use Tart Images in your `.gitlab-ci.yml`:
 ```yaml
 # You can use any remote Tart Image.
 # Tart Executor will pull it from the registry and use it for creating ephemeral VMs.
-image: ghcr.io/cirruslabs/macos-sequoia-base:latest
+image: ghcr.io/cirruslabs/macos-tahoe-base:latest
 
 test:
   tags:

--- a/docs/integrations/packer.md
+++ b/docs/integrations/packer.md
@@ -17,8 +17,8 @@ packer {
 }
 
 source "tart-cli" "tart" {
-  vm_base_name = "ghcr.io/cirruslabs/macos-sequoia-base:latest"
-  vm_name      = "my-custom-sequoia"
+  vm_base_name = "ghcr.io/cirruslabs/macos-tahoe-base:latest"
+  vm_name      = "my-custom-tahoe"
   cpu_count    = 4
   memory_gb    = 8
   disk_size_gb = 70

--- a/docs/orchard/integration-guide.md
+++ b/docs/orchard/integration-guide.md
@@ -85,7 +85,7 @@ def main():
   # Create VM
   response = requests.post("http://127.0.0.1:6120/v1/vms", auth=basic_auth, json={
     "name": vm_name,
-    "image": "ghcr.io/cirruslabs/macos-sequoia-base:latest",
+    "image": "ghcr.io/cirruslabs/macos-tahoe-base:latest",
     "cpu": 4,
     "memory": 4096,
     "startup_script": {
@@ -144,7 +144,7 @@ func main() {
     Meta: v1.Meta{
       Name: vmName,
     },
-    Image:  "ghcr.io/cirruslabs/macos-sequoia-base:latest",
+    Image:  "ghcr.io/cirruslabs/macos-tahoe-base:latest",
     CPU:    4,
     Memory: 4096,
     StartupScript: &v1.VMScript{

--- a/docs/orchard/quick-start.md
+++ b/docs/orchard/quick-start.md
@@ -26,7 +26,7 @@ more information.
 Now, let's create a Virtual Machine:
 
 ```shell
-orchard create vm --image ghcr.io/cirruslabs/macos-sequoia-base:latest sequoia-base
+orchard create vm --image ghcr.io/cirruslabs/macos-tahoe-base:latest tahoe-base
 ```
 
 You can check a list of VM resources to see if the Virtual Machine we've created above is already running:
@@ -48,7 +48,7 @@ instance. Orchard Controller instance is secured by default and all API calls ar
 To SSH into a VM, use the `orchard ssh` command:
 
 ```shell
-orchard ssh vm sequoia-base
+orchard ssh vm tahoe-base
 ```
 
 You can specify the `--username` and `--password` flags to specify the username/password pair to use for the SSH
@@ -58,14 +58,14 @@ You can also execute remote commands instead of spawning a login shell, similarl
 a command argument:
 
 ```shell
-orchard ssh vm sequoia-base "uname -a"
+orchard ssh vm tahoe-base "uname -a"
 ```
 
 You can execute scripts remotely this way, by telling the remote command-line interpreter to read from the standard
 input and using the redirection operator as follows:
 
 ```shell
-orchard ssh vm sequoia-base "bash -s" < script.sh
+orchard ssh vm tahoe-base "bash -s" < script.sh
 ```
 
 ### VNC
@@ -73,7 +73,7 @@ orchard ssh vm sequoia-base "bash -s" < script.sh
 Similarly to `ssh` command, you can use `vnc` command to open Screen Sharing into a remote VM:
 
 ```shell
-orchard vnc vm sequoia-base
+orchard vnc vm tahoe-base
 ```
 
 You can specify the `--username` and `--password` flags to specify the username/password pair to use for the VNC
@@ -84,7 +84,7 @@ protocol. By default, `admin`/`admin` is used.
 The following command will delete the VM we've created above and clean-up the resources associated with it:
 
 ```shell
-orchard delete vm sequoia-base
+orchard delete vm tahoe-base
 ```
 
 ## Environment variables

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -40,7 +40,7 @@ The following macOS images are currently available:
     * `ghcr.io/cirruslabs/macos-tahoe-xcode:latest`
 * macOS 15 (Sequoia)
     * `ghcr.io/cirruslabs/macos-sequoia-vanilla:latest`
-    * `ghcr.io/cirruslabs/macos-sequoia-base:latest`
+    * `ghcr.io/cirruslabs/macos-tahoe-base:latest`
     * `ghcr.io/cirruslabs/macos-sequoia-xcode:latest`
 * macOS 14 (Sonoma)
     * `ghcr.io/cirruslabs/macos-sonoma-vanilla:latest`

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -40,7 +40,7 @@ The following macOS images are currently available:
     * `ghcr.io/cirruslabs/macos-tahoe-xcode:latest`
 * macOS 15 (Sequoia)
     * `ghcr.io/cirruslabs/macos-sequoia-vanilla:latest`
-    * `ghcr.io/cirruslabs/macos-tahoe-base:latest`
+    * `ghcr.io/cirruslabs/macos-sequoia-base:latest`
     * `ghcr.io/cirruslabs/macos-sequoia-xcode:latest`
 * macOS 14 (Sonoma)
     * `ghcr.io/cirruslabs/macos-sonoma-vanilla:latest`

--- a/scripts/run-signed.sh
+++ b/scripts/run-signed.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # helper script to build and run a signed tart binary
-# usage: ./scripts/run-signed.sh run sequoia-base
+# usage: ./scripts/run-signed.sh run macos
 
 set -e
 


### PR DESCRIPTION
Fixes all the missing bits and pieces from https://github.com/cirruslabs/tart/pull/1206.