### PR TITLE
docs: clarify that nested virtualization is only for Linux VMs for now

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -59,7 +59,7 @@ Remote images are pulled into `~/.tart/cache/OCIs/`.
 ## Nested virtualization support?
 
 Tart is limited by functionality of Apple's `Virtualization.Framework`. At the moment `Virtualization.Framework`
-supports nested virtualization only on M3 or M4 chips running macOS 15 (Sequoia) or later. By default, it is disabled, but can be enabled by passing the `--nested` flag to `tart run`.
+supports nested virtualization only on M3 or M4 chips running macOS 15 (Sequoia) or later and [only for Linux VMs](https://github.com/cirruslabs/tart/issues/1231#issuecomment-4410915463). By default, it is disabled, but can be enabled by passing the `--nested` flag to `tart run`.
 
 ## Connecting to a service running on host
 

--- a/integration-tests/test_oci.py
+++ b/integration-tests/test_oci.py
@@ -46,7 +46,7 @@ def vm_with_random_disk(tart):
     disk_path = os.path.join(tart.home(), "vms", vm_name, "disk.img")
 
     with tempfile.NamedTemporaryFile(delete=False) as tf:
-        tf.write(os.urandom(amount_to_transfer.bytes))
+        tf.write(os.urandom(int(amount_to_transfer.bytes)))
         tf.close()
         os.rename(tf.name, disk_path)
 


### PR DESCRIPTION
See https://github.com/cirruslabs/tart/issues/1231#issuecomment-4410915463.

Also account for [bitmath 2.0.0](https://github.com/timlnx/bitmath/releases/tag/v2.0.0) using `float` instead of `int` to fix the `TypeError` in integration tests.