### PR TITLE
fix(homebrew): wrap macOS version dependency in on_macos block

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,7 +72,9 @@ brews:
       libexec.install Dir["*"]
       bin.write_exec_script "#{libexec}/tart.app/Contents/MacOS/tart"
     custom_block: |
-      depends_on :macos => :ventura
+      on_macos do
+        depends_on :macos => :ventura
+      end
       def post_install
         generate_completions_from_executable(libexec/"tart.app/Contents/MacOS/tart", "--generate-completion-script")
       end


### PR DESCRIPTION
GoReleaser's Homebrew template always emits a bare `depends_on :macos` for macOS-only formulae. Combining that with the `depends_on :macos => :ventura` line injected via custom_block triggers a Homebrew deprecation warning on `brew upgrade`:

```
  Warning: Calling `depends_on :macos` with `depends_on macos:` is deprecated! Use `depends_on :macos` with `depends_on macos:` inside an `on_macos` block instead.
  Please report this issue to the cirruslabs/homebrew-cli tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
    /opt/homebrew/Library/Taps/cirruslabs/homebrew-cli/tart.rb:22
```

Declaring the version constraint inside an `on_macos` block is the form Homebrew recommends and silences the warning without changing behavior (still macOS-only, Ventura or newer).

Upstream issue:

- https://github.com/cirruslabs/homebrew-cli/issues/14

Related PR for `softnet` formula, which I also use:

- https://github.com/openai/softnet/pull/169