### PR TITLE
goreleaser: nest versioned depends_on macos in on_macos block

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,7 +72,9 @@ brews:
       libexec.install Dir["*"]
       bin.write_exec_script "#{libexec}/tart.app/Contents/MacOS/tart"
     custom_block: |
-      depends_on :macos => :ventura
+      on_macos do
+        depends_on macos: :ventura
+      end
       def post_install
         generate_completions_from_executable(libexec/"tart.app/Contents/MacOS/tart", "--generate-completion-script")
       end


### PR DESCRIPTION
The generated Homebrew formula emits a deprecation warning on every brew command:

    Warning: Calling `depends_on :macos` with `depends_on macos:` is
    deprecated! Use `depends_on :macos` with `depends_on macos:` inside
    an `on_macos` block instead.
      cirruslabs/homebrew-cli/tart.rb:22

This wraps the versioned `depends_on :macos => :ventura` in the goreleaser
`custom_block` in an `on_macos` block as Homebrew now requires, so future
releases regenerate the formula without the warning. No behavior change.

Companion PR fixing the currently published formula: cirruslabs/homebrew-cli#15